### PR TITLE
fix: add Loader argument to yaml.load() for PyYAML 6.0 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,24 @@
 # -*- coding: utf-8 -*-
 
 import yaml
+from setuptools import find_packages, setup
 
-from setuptools import find_packages
-from setuptools import setup
-
-with open('wazo/plugin.yml') as file:
-    metadata = yaml.load(file)
+with open("wazo/plugin.yml") as file:
+    metadata = yaml.load(file, Loader=yaml.SafeLoader)
 
 setup(
-    name=metadata['name'],
-    version=metadata['version'],
-    description=metadata['display_name'],
-    author=metadata['author'],
-    url=metadata['homepage'],
-
+    name=metadata["name"],
+    version=metadata["version"],
+    description=metadata["display_name"],
+    author=metadata["author"],
+    url=metadata["homepage"],
     packages=find_packages(),
     include_package_data=True,
     package_data={
-        'wazo_calld_queue': ['api.yml'],
+        "wazo_calld_queue": ["api.yml"],
     },
     entry_points={
-        'wazo_calld.plugins': [
-            'queue = wazo_calld_queue.plugin:Plugin'
-        ],
-        'wazo_call_logd.plugins': [
-            'queue_log = wazo_call_logd_queue.plugin:Plugin'
-        ],
+        "wazo_calld.plugins": ["queue = wazo_calld_queue.plugin:Plugin"],
+        "wazo_call_logd.plugins": ["queue_log = wazo_call_logd_queue.plugin:Plugin"],
     },
 )


### PR DESCRIPTION
- PyYAML 6.0 requires explicit Loader argument for security reasons
- Use SafeLoader to prevent arbitrary code execution
- Clean up imports and formatting for consistency