### PR TITLE
feat: support agents belonging to multiple queues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Version source: `wazo/plugin.yml`.
 - `wazo_call_logd_queue/`: `wazo-call-logd` plugin. Persists Asterisk `queue_log` entries to the database and publishes bus events.
 - `etc/`: deployed configuration, including Asterisk dialplan, ACL, and plugin activation.
 - `tests/`: pytest unit tests. `conftest.py` stubs `wazo_bus` so `bus_consume` imports without the full Wazo stack.
+- `wazo_calld_queue/api.yml`: Swagger 2.0 fragment (field-level REST reference, merged into the global `wazo-calld` spec).
+- `docs/FRONTEND_INTEGRATION.md`: integration guide for frontend clients — REST/event semantics, the multi-queue agent model, and snapshot+subscribe merge logic.
 
 ## Core module map (`wazo_calld_queue/`)
 
@@ -24,6 +26,10 @@ Version source: `wazo/plugin.yml`.
 - Map REST API calls to Asterisk Manager Interface actions.
 - Consume `QueueCaller*` and `QueueMember*` bus events in `bus_consume.py`.
 - Maintain global in-memory dicts: `stats` and `agents`.
+- An agent may serve several queues: each `agents[tenant][id]` tracks runtime
+  membership in `queues` and per-queue pause in `paused_queues`; `queue`,
+  `is_logged`, and `is_paused` are derived from these via `_sync_derived` and
+  never written directly.
 - Republish enriched events to the front-end websocket.
 - Treat in-memory state as non-shared across workers and non-persistent across restarts.
 - Resolve tenant UUID from `WAZO_TENANT_UUID` or confd via `_extract_tenant_uuid`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/FRONTEND_INTEGRATION.md`: a frontend integration guide covering REST and
   event semantics, the multi-queue agent model, and client merge logic.
 - Sync the `QueueAgentsStatus` Swagger definition with the real payload (add the
-  multi-queue and previously undocumented fields; fix the `is_loggued` /
-  `loggued_at` typos to `is_logged` / `logged_at`).
+  multi-queue and previously undocumented fields including `interface`; sharpen
+  the `is_ringing` / `is_talking` / `talked_at` descriptions; fix the
+  `is_loggued` / `loggued_at` typos to `is_logged` / `logged_at`).
 
 ### Fixed
 - An agent removed from one queue is no longer wrongly reported as fully logged
   out while still a member of other queues.
 - Pausing or unpausing in one queue no longer flips the agent's global pause
   state for all queues.
+- Malformed `QueueMember*` events missing a required field (e.g. `Queue`) are
+  now dropped with a warning instead of raising and aborting the event batch.
+- A pause event for a queue the agent is not a member of is now ignored,
+  preventing a logged-out agent from being reported as paused (keeps the
+  `paused_queues` ⊆ `queues` invariant).
 
 ## [2.1.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-06-18
+
+### Added
+- Support agents belonging to multiple queues: each agent now tracks runtime
+  membership (`queues`) and per-queue pause (`paused_queues`); these are exposed
+  alongside the existing `queue` field in REST and bus payloads.
+- `docs/FRONTEND_INTEGRATION.md`: a frontend integration guide covering REST and
+  event semantics, the multi-queue agent model, and client merge logic.
+- Sync the `QueueAgentsStatus` Swagger definition with the real payload (add the
+  multi-queue and previously undocumented fields; fix the `is_loggued` /
+  `loggued_at` typos to `is_logged` / `logged_at`).
+
+### Fixed
+- An agent removed from one queue is no longer wrongly reported as fully logged
+  out while still a member of other queues.
+- Pausing or unpausing in one queue no longer flips the agent's global pause
+  state for all queues.
+
 ## [2.1.0] - 2026-06-18
 
 ### Changed
@@ -59,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release: Queue REST API and bus events for Asterisk-based queue management.
 
+[2.2.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.0.0...v2.0.1

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -1,0 +1,320 @@
+<!-- Copyright 2026 The Wazo Authors  (see the AUTHORS file) -->
+<!-- SPDX-License-Identifier: GPL-3.0+ -->
+
+# Frontend integration guide
+
+Audience: a frontend developer **or coding agent** building a real-time queue
+dashboard against this plugin. The Swagger fragment
+(`wazo_calld_queue/api.yml`) is the field-by-field reference; this document
+explains the **semantics** you must respect to implement a correct client.
+
+> If anything here disagrees with the code, the code wins. Endpoints are
+> registered in `plugin.py`, events declared in `events.py`, and the in-memory
+> model lives in `bus_consume.py`.
+
+---
+
+## 1. Mental model
+
+The server keeps **in-memory, per-worker, non-persistent** state:
+
+- `stats[queue_name]` — live counters per queue.
+- `agents[tenant_uuid][agent_id]` — live status per agent.
+
+Two consequences for the client:
+
+1. **Never treat the server as a durable source of truth.** State is rebuilt
+   from Asterisk events after a restart and is **not shared across workers**, so
+   two REST calls may hit different workers with slightly different snapshots.
+   Trust the live event stream, not repeated polling.
+2. The correct pattern is **snapshot + subscribe**:
+   1. `GET` the REST endpoint once to bootstrap (full map).
+   2. Subscribe to the matching bus/websocket event for incremental updates.
+   3. Merge each event into your local store **by key** (agent `id`, or queue
+      `name`).
+
+Do **not** poll REST on a timer — you will fight the event stream and miss
+transitions.
+
+---
+
+## 2. Authentication & ACL
+
+All REST endpoints are `wazo-auth` protected; pass a valid token. Required ACLs
+(from `resources.py`):
+
+| Endpoint | ACL |
+|---|---|
+| `GET /queues` | `calld.queues.read` |
+| `GET /queues/{queue_name}` | `calld.queues.{queue_name}.read` |
+| `GET /queues/{queue_name}/livestats` | `calld.queues.{queue_name}.livestats.read` |
+| `GET /queues/agents_status` | `calld.queues.agents_status.read` |
+| `PUT /queues/{queue_name}/add_member` | `calld.queues.{queue_name}.add_member.update` |
+| `PUT /queues/{queue_name}/remove_member` | `calld.queues.{queue_name}.remove_member.update` |
+| `PUT /queues/{queue_name}/pause_member` | `calld.queues.{queue_name}.pause_member.update` |
+| `POST /queues/intercept/{queue_name}` | `calld.queues.{queue_name}.intercept.create` |
+
+Bus/websocket events all require `events.calls.me` and are tenant-scoped: you
+only receive events for your own tenant.
+
+---
+
+## 3. REST endpoints (bootstrap & actions)
+
+| Method | Path | Purpose | Returns |
+|---|---|---|---|
+| `GET` | `/queues` | List queues (live AMI summary) | `{ "items": [QueueList] }` |
+| `GET` | `/queues/{queue_name}` | One queue's detailed status + members | `Queue` |
+| `GET` | `/queues/{queue_name}/livestats` | Live counters for **one** queue | `QueueStats` |
+| `GET` | `/queues/agents_status` | **Full map** of agents for the tenant | `{ "<agent_id>": QueueAgentsStatus, ... }` |
+| `PUT` | `/queues/{queue_name}/add_member` | Log a member into a queue | `204` |
+| `PUT` | `/queues/{queue_name}/remove_member` | Remove a member from a queue | `204` |
+| `PUT` | `/queues/{queue_name}/pause_member` | Pause/unpause a member in a queue | `204` |
+| `POST` | `/queues/intercept/{queue_name}` | Intercept a waiting caller | `201` |
+
+`add_member` / `remove_member` / `pause_member` act on **a single queue**. To
+manage an agent serving several queues, call them once per queue.
+
+---
+
+## 4. Bus / websocket events
+
+Subscribe via the Wazo websocket (`wazo-websocketd`). Every event below is a
+`calld` service event, ACL `events.calls.me`.
+
+| Routing key | Event name | Payload shape | Use for |
+|---|---|---|---|
+| `calls.queue.agents.status` | `queue_agents_status` | **single** `QueueAgentsStatus` | live agent updates |
+| `calls.queue.livestats` | `queue_livestats` | **whole** stats map `{queue_name: QueueStats}` | live queue counters |
+| `calls.queue.caller.join` | `queue_caller_join` | raw Asterisk event | low-level caller tracking |
+| `calls.queue.caller.leave` | `queue_caller_leave` | raw Asterisk event | low-level caller tracking |
+| `calls.queue.caller.abandon` | `queue_caller_abandon` | raw Asterisk event | low-level caller tracking |
+| `calls.queue.member.added` | `queue_member_added` | raw Asterisk event | low-level membership |
+| `calls.queue.member.removed` | `queue_member_removed` | raw Asterisk event | low-level membership |
+| `calls.queue.member.pause` | `queue_member_pause` | raw Asterisk event | low-level pause |
+| `calls.queue.member.penalty` | `queue_member_penalty` | raw Asterisk event | low-level penalty |
+| `calls.queue.member.ringinuse` | `queue_member_ringinuse` | raw Asterisk event | low-level ringinuse |
+| `calls.queue.member.status` | `queue_member_status` | raw Asterisk event | low-level device status |
+
+### ⚠️ Shape mismatch between REST and events — read this twice
+
+The bootstrap REST shape and the live event shape are **deliberately
+different**. Get this wrong and your store will be corrupt:
+
+- **Agents:** `GET /queues/agents_status` returns the **full map**
+  `{ "<id>": {agent} }`. The `queue_agents_status` event carries **one** agent
+  object (`{agent}`), not the map. → Merge it by `agent.id`.
+- **Live stats:** `GET /queues/{name}/livestats` returns **one** queue's stats
+  object. The `queue_livestats` event carries the **whole** map
+  `{ "<queue_name>": {stats} }`. → Replace/merge per `queue_name`.
+
+The raw `caller.*` / `member.*` events are the low-level Asterisk source that
+the server already digests into `agents_status` and `livestats`. **Prefer the
+two digested events** for UI state; use the raw ones only for fine-grained
+needs (e.g. animating an individual caller join).
+
+---
+
+## 5. The multi-queue agent model (most important section)
+
+An agent can serve **several queues at once**. Each agent object exposes:
+
+| Field | Type | Meaning | Level |
+|---|---|---|---|
+| `id` | int | agent id (merge key) | — |
+| `number` | string | agent number | — |
+| `fullname` | string | display name | — |
+| `queues` | string[] | queues the agent is **currently** a member of (runtime) | per-queue |
+| `paused_queues` | string[] | queues in which the agent is **currently paused** | per-queue |
+| `queue` | string \| false | **first** of `queues` — kept for backward compat | derived |
+| `is_logged` | bool | `queues` is non-empty | derived |
+| `is_paused` | bool | `paused_queues` is non-empty | derived |
+| `is_ringing` | bool | the agent's device is ringing | **device** |
+| `is_talking` | bool | the agent is in a call | **device** |
+| `is_offline` | bool | the agent device/websocket is down | **device** |
+| `logged_at` | string | login time (first queue join) | session |
+| `paused_at` | string | time of first active pause | session |
+| `talked_at` | string | start of current call | session |
+| `talked_with_number` / `talked_with_name` | string | current caller | session |
+
+Rules to implement correctly:
+
+- **Use `queues`, not `queue`.** `queue` is only the first element, provided so
+  older clients keep working. A multi-queue UI must read `queues`.
+- **`is_logged` / `is_paused` / `queue` are derived — never authoritative on
+  their own.** They are recomputed server-side from `queues` / `paused_queues`.
+  If you mirror this logic client-side, derive the same way:
+  `is_logged = queues.length > 0`, `is_paused = paused_queues.length > 0`.
+- **Device fields are global, not per-queue.** `is_talking` / `is_ringing` /
+  `is_offline` reflect the agent's phone, the same across all their queues.
+  Don't render them per queue.
+- **`logged_at` / `paused_at` are "since first".** They are set on the first
+  queue join / first pause and preserved while at least one queue / pause
+  remains; they only clear when the agent leaves the **last** queue / unpauses
+  the **last** queue.
+
+---
+
+## 6. Agent lifecycle — how actions map to state
+
+Asterisk emits **one membership event per queue**. The server folds them into
+the agent object; the client just consumes `queue_agents_status`.
+
+| User action | What happens server-side | Resulting agent state |
+|---|---|---|
+| Log into queue A | `queues += [A]`, `logged_at` set if first | `is_logged: true`, `queue: "A"` |
+| Also log into queue B | `queues += [B]` | `queues: ["A","B"]`, `is_logged` stays true |
+| Remove from queue A only | `queues -= [A]` (also drops A from `paused_queues`) | `queues: ["B"]`, **`is_logged` stays true** |
+| Remove from the last queue | `queues` empties → session reset | `is_logged: false`, `queue: false`, device/session fields cleared |
+| Pause in queue B | `paused_queues += [B]`, `paused_at` set if first | `is_paused: true` |
+| Unpause queue A (still paused in B) | `paused_queues -= [A]` | `is_paused` stays true |
+| Unpause the last paused queue | `paused_queues` empties | `is_paused: false`, `paused_at: ""` |
+
+> **The bug this model fixes:** before multi-queue support, removing an agent
+> from *one* queue marked them fully logged out and wiped their session, even
+> though they were still serving other queues. If you see a client assuming
+> "one remove event = logged out", it is wrong — only the **last** removal
+> logs the agent out.
+
+---
+
+## 7. Concrete payloads
+
+### `GET /queues/agents_status` (bootstrap — full map)
+
+```json
+{
+  "5": {
+    "id": 5,
+    "number": "1001",
+    "fullname": "John Doe",
+    "queue": "support",
+    "queues": ["support", "sales"],
+    "paused_queues": ["sales"],
+    "is_logged": true,
+    "is_paused": true,
+    "is_ringing": false,
+    "is_talking": true,
+    "is_offline": false,
+    "logged_at": "2026-06-18T09:00:00.000000",
+    "paused_at": "2026-06-18T10:30:00.000000",
+    "talked_at": "2026-06-18T11:05:00.000000",
+    "talked_with_number": "2000",
+    "talked_with_name": "Alice"
+  }
+}
+```
+
+### `queue_agents_status` event (live — single agent)
+
+The websocket envelope wraps the payload in `data` (Wazo convention). The
+`data` is **one** agent object, same shape as a single value of the map above:
+
+```json
+{
+  "name": "queue_agents_status",
+  "data": {
+    "id": 5,
+    "number": "1001",
+    "fullname": "John Doe",
+    "queue": "sales",
+    "queues": ["sales"],
+    "paused_queues": [],
+    "is_logged": true,
+    "is_paused": false,
+    "is_ringing": false,
+    "is_talking": false,
+    "is_offline": false,
+    "logged_at": "2026-06-18T09:00:00.000000",
+    "paused_at": "",
+    "talked_at": "",
+    "talked_with_number": "",
+    "talked_with_name": ""
+  }
+}
+```
+
+### `queue_livestats` event (live — whole map)
+
+```json
+{
+  "name": "queue_livestats",
+  "data": {
+    "support": {
+      "count": 2,
+      "count_color": "red",
+      "received": 10,
+      "abandonned": 1,
+      "answered": 9,
+      "awr": 90,
+      "waiting_calls": [
+        {
+          "uniqueid": "1718700000.42",
+          "calleridnum": "2000",
+          "calleridname": "Alice",
+          "position": "1",
+          "channelstate": "6",
+          "channelstatedesc": "Up",
+          "time": "0",
+          "entryexten": "4000"
+        }
+      ],
+      "updated_at": 18
+    }
+  }
+}
+```
+
+`count_color` is `"green"` when `count <= 1`, `"red"` above. `awr` is the
+answer/received ratio in percent. `updated_at` is the day-of-month of the last
+update; counters reset when the day changes.
+
+---
+
+## 8. Client merge logic (pseudo-code)
+
+```js
+// Bootstrap
+const agents = await GET('/queues/agents_status');   // { [id]: agent }
+const stats  = {};
+for (const q of knownQueues) {
+  stats[q] = await GET(`/queues/${q}/livestats`);     // single object
+}
+
+// Live updates
+websocket.on('queue_agents_status', ({ data: agent }) => {
+  agents[agent.id] = agent;                           // replace by id
+});
+
+websocket.on('queue_livestats', ({ data: map }) => {
+  Object.assign(stats, map);                          // merge by queue name
+});
+
+// Rendering an agent's queues (multi-queue aware)
+function renderAgent(a) {
+  const queues = a.queues;                            // NOT a.queue
+  const paused = new Set(a.paused_queues);
+  return queues.map(q => ({
+    queue: q,
+    paused: paused.has(q),                            // per-queue pause
+  }));
+  // a.is_talking / a.is_ringing / a.is_offline are global to the agent
+}
+```
+
+---
+
+## 9. Caveats & edge cases
+
+- **Initial state is best-effort.** On first build from confd, the server does
+  not know per-queue pause or per-queue membership, so it seeds `queues` from
+  the agent's configured queues (only when logged in) and mirrors pause across
+  them. Live events correct this within moments. Don't hard-fail on a brief
+  inconsistency right after startup.
+- **`talked_with_*` is populated on `QueueCallerLeave`** (when a caller is
+  connected to the agent) and cleared when the call ends.
+- **`queue: false`** means the agent is in no queue (logged out). Handle the
+  boolean-vs-string union.
+- **Per-worker state:** if your token is load-balanced across workers, a
+  `GET /queues/agents_status` may briefly differ from the event stream. Reconcile
+  toward the events.

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -39,6 +39,41 @@ def _join_event(uniqueid, queue="support", count="1", tenant=TENANT):
     }
 
 
+def _member_added_event(queue, agent_id=5, member="1001", tenant=TENANT):
+    return {
+        "Event": "QueueMemberAdded",
+        "Membership": "dynamic",
+        "Interface": f"Local/id-{agent_id}@agentcallback",
+        "MemberName": f"Agent/{member}",
+        "StateInterface": f"Local/id-{agent_id}@agentcallback",
+        "Queue": queue,
+        "ChanVariable": {"WAZO_TENANT_UUID": tenant},
+    }
+
+
+def _member_removed_event(queue, agent_id=5, member="1001", tenant=TENANT):
+    return {
+        "Event": "QueueMemberRemoved",
+        "Membership": "dynamic",
+        "Interface": f"Local/id-{agent_id}@agentcallback",
+        "MemberName": f"Agent/{member}",
+        "Queue": queue,
+        "ChanVariable": {"WAZO_TENANT_UUID": tenant},
+    }
+
+
+def _member_pause_event(queue, paused, agent_id=5, member="1001", tenant=TENANT):
+    return {
+        "Event": "QueueMemberPause",
+        "Membership": "dynamic",
+        "Interface": f"Local/id-{agent_id}@agentcallback",
+        "MemberName": f"Agent/{member}",
+        "Queue": queue,
+        "Paused": paused,
+        "ChanVariable": {"WAZO_TENANT_UUID": tenant},
+    }
+
+
 def _published_events(handler):
     return [call.args[0] for call in handler.bus_publisher.publish.call_args_list]
 
@@ -227,6 +262,73 @@ class TestGetAgentsStatus:
         assert result[2]["queue"] is False
         assert result[2]["is_logged"] is False
 
+    def test_collects_all_configured_queues(self, handler):
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {
+                    "id": 1,
+                    "firstname": "John",
+                    "lastname": "Doe",
+                    "number": "1001",
+                    "queues": [{"name": "support"}, {"name": "sales"}],
+                }
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = [
+            SimpleNamespace(id=1, logged=True, paused=False),
+        ]
+
+        result = handler.get_agents_status(TENANT)
+
+        assert result[1]["queues"] == ["support", "sales"]
+        assert result[1]["queue"] == "support"
+        assert result[1]["is_logged"] is True
+
+    def test_queues_empty_when_logged_out(self, handler):
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {
+                    "id": 1,
+                    "firstname": "John",
+                    "lastname": "Doe",
+                    "number": "1001",
+                    "queues": [{"name": "support"}, {"name": "sales"}],
+                }
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = [
+            SimpleNamespace(id=1, logged=False, paused=False),
+        ]
+
+        result = handler.get_agents_status(TENANT)
+
+        # Runtime membership stays consistent with the logged-out status.
+        assert result[1]["queues"] == []
+        assert result[1]["queue"] is False
+        assert result[1]["is_logged"] is False
+        assert result[1]["paused_queues"] == []
+
+    def test_paused_queues_seeded_when_paused(self, handler):
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {
+                    "id": 1,
+                    "firstname": "John",
+                    "lastname": "Doe",
+                    "number": "1001",
+                    "queues": [{"name": "support"}, {"name": "sales"}],
+                }
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = [
+            SimpleNamespace(id=1, logged=True, paused=True),
+        ]
+
+        result = handler.get_agents_status(TENANT)
+
+        assert result[1]["paused_queues"] == ["support", "sales"]
+        assert result[1]["is_paused"] is True
+
     def test_result_is_cached(self, handler):
         handler.confd.agents.list.return_value = {
             "items": [
@@ -262,8 +364,28 @@ class TestAddAgent:
         assert agent["id"] == 5
         assert agent["number"] == "1001"
         assert agent["fullname"] == "John Doe"
-        assert agent["queue"] == "support"
+        # add_agent starts not-yet-logged: the triggering membership event
+        # populates ``queues`` (and hence the derived ``queue``) right after.
+        assert agent["queue"] is False
         assert agent["is_logged"] is False
+
+    def test_initializes_multi_queue(self, handler):
+        bus_consume.agents[TENANT] = {}
+        handler.confd.agents.get.return_value = {
+            "firstname": "John",
+            "lastname": "Doe",
+            "queues": [{"name": "support"}, {"name": "sales"}],
+        }
+
+        handler.add_agent(TENANT, 5, "1001")
+
+        agent = bus_consume.agents[TENANT][5]
+        # add_agent seeds the configured queues but the agent is not yet
+        # runtime-logged, so derived membership starts empty.
+        assert agent["queues"] == []
+        assert agent["queue"] is False
+        assert agent["is_logged"] is False
+        assert agent["paused_queues"] == []
 
     def test_does_not_overwrite_existing_agent(self, handler):
         bus_consume.agents[TENANT] = {5: {"id": 5, "fullname": "Existing"}}
@@ -317,6 +439,8 @@ class TestMemberEventHandlers:
                 "id": 5,
                 "number": "1001",
                 "queue": "support",
+                "queues": ["support"],
+                "paused_queues": [],
                 "is_paused": False,
                 "paused_at": "",
             }
@@ -347,6 +471,8 @@ class TestMemberEventHandlers:
                 "id": 5,
                 "number": "1001",
                 "queue": "support",
+                "queues": ["support"],
+                "paused_queues": [],
                 "is_talking": False,
                 "is_ringing": True,
                 "talked_at": "",
@@ -390,3 +516,114 @@ class TestCallerEventHandlers:
         published = _published_events(handler)
         assert len(published) == 1
         assert isinstance(published[0], QueueCallerJoinEvent)
+
+
+class TestMultiQueueMembership:
+    def _logged_agent(self, queues, paused_queues=None):
+        """Seed an agent already logged into ``queues`` (runtime membership)."""
+        bus_consume.agents[TENANT] = {
+            5: {
+                "id": 5,
+                "number": "1001",
+                "fullname": "John Doe",
+                "queue": queues[0] if queues else False,
+                "queues": list(queues),
+                "paused_queues": list(paused_queues or []),
+                "is_logged": bool(queues),
+                "is_paused": bool(paused_queues),
+                "is_offline": False,
+                "is_talking": False,
+                "is_ringing": False,
+                "logged_at": "2026-06-17T12:00:00.000000",
+                "paused_at": "",
+                "talked_at": "",
+                "talked_with_number": "",
+                "talked_with_name": "",
+            }
+        }
+        return bus_consume.agents[TENANT][5]
+
+    def test_member_added_to_second_queue_keeps_both(self, handler):
+        self._logged_agent(["support"])
+
+        handler._queue_member_added(_member_added_event("sales"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == ["support", "sales"]
+        assert agent["is_logged"] is True
+
+    def test_member_removed_from_one_queue_stays_logged(self, handler):
+        self._logged_agent(["support", "sales"])
+
+        handler._queue_member_removed(_member_removed_event("sales"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == ["support"]
+        assert agent["is_logged"] is True
+        # Session is preserved while still member of another queue.
+        assert agent["logged_at"] == "2026-06-17T12:00:00.000000"
+
+    def test_member_removed_from_last_queue_logs_out(self, handler):
+        agent = self._logged_agent(["support"])
+        agent["is_talking"] = True
+        agent["talked_at"] = "2026-06-17T12:30:00.000000"
+        agent["talked_with_number"] = "2000"
+
+        handler._queue_member_removed(_member_removed_event("support"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == []
+        assert agent["is_logged"] is False
+        assert agent["is_talking"] is False
+        assert agent["is_ringing"] is False
+        assert agent["logged_at"] == ""
+        assert agent["talked_at"] == ""
+        assert agent["talked_with_number"] == ""
+
+    def test_queue_field_is_first_of_queues(self, handler):
+        self._logged_agent(["support"])
+
+        handler._queue_member_added(_member_added_event("sales"))
+        assert bus_consume.agents[TENANT][5]["queue"] == "support"
+
+        handler._queue_member_removed(_member_removed_event("support"))
+        assert bus_consume.agents[TENANT][5]["queue"] == "sales"
+
+        handler._queue_member_removed(_member_removed_event("sales"))
+        assert bus_consume.agents[TENANT][5]["queue"] is False
+
+    def test_pause_in_one_queue_among_two_sets_paused(self, handler):
+        self._logged_agent(["support", "sales"])
+
+        handler._queue_member_pause(_member_pause_event("sales", paused="1"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["paused_queues"] == ["sales"]
+        assert agent["is_paused"] is True
+        assert agent["paused_at"] != ""
+
+    def test_unpause_one_of_two_paused_queues_stays_paused(self, handler):
+        agent = self._logged_agent(["support", "sales"])
+        agent["paused_queues"] = ["support", "sales"]
+        agent["is_paused"] = True
+        agent["paused_at"] = "2026-06-17T12:15:00.000000"
+
+        handler._queue_member_pause(_member_pause_event("support", paused="0"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["paused_queues"] == ["sales"]
+        assert agent["is_paused"] is True
+        assert agent["paused_at"] == "2026-06-17T12:15:00.000000"
+
+    def test_unpause_last_queue_clears_paused(self, handler):
+        agent = self._logged_agent(["support"])
+        agent["paused_queues"] = ["support"]
+        agent["is_paused"] = True
+        agent["paused_at"] = "2026-06-17T12:15:00.000000"
+
+        handler._queue_member_pause(_member_pause_event("support", paused="0"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["paused_queues"] == []
+        assert agent["is_paused"] is False
+        assert agent["paused_at"] == ""

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -627,3 +627,138 @@ class TestMultiQueueMembership:
         assert agent["paused_queues"] == []
         assert agent["is_paused"] is False
         assert agent["paused_at"] == ""
+
+    def test_duplicate_added_event_is_idempotent(self, handler):
+        self._logged_agent(["support"])
+
+        handler._queue_member_added(_member_added_event("support"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == ["support"]
+
+    def test_duplicate_pause_event_is_idempotent(self, handler):
+        agent = self._logged_agent(["support"])
+        agent["paused_queues"] = ["support"]
+        agent["is_paused"] = True
+        agent["paused_at"] = "2026-06-17T12:15:00.000000"
+
+        handler._queue_member_pause(_member_pause_event("support", paused="1"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["paused_queues"] == ["support"]
+        # Already paused: the first-pause timestamp must be preserved.
+        assert agent["paused_at"] == "2026-06-17T12:15:00.000000"
+
+    def test_pause_in_non_member_queue_is_ignored(self, handler):
+        # Agent is a member of "support" only; a pause for "sales" is dropped to
+        # keep the invariant paused_queues ⊆ queues.
+        self._logged_agent(["support"])
+
+        handler._queue_member_pause(_member_pause_event("sales", paused="1"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["paused_queues"] == []
+        assert agent["is_paused"] is False
+
+    def test_pause_after_removed_does_not_resurrect_membership(self, handler):
+        # Removed then a stray Pause for the same queue: the agent is logged out
+        # and must not be reported as paused.
+        self._logged_agent(["support"])
+
+        handler._queue_member_removed(_member_removed_event("support"))
+        handler._queue_member_pause(_member_pause_event("support", paused="1"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == []
+        assert agent["paused_queues"] == []
+        assert agent["is_logged"] is False
+        assert agent["is_paused"] is False
+
+
+class TestBuildAgentState:
+    def test_seeds_runtime_queues_when_logged(self):
+        state = bus_consume._build_agent_state(
+            1, "1001", "John Doe", ["support", "sales"], is_logged=True, is_paused=False
+        )
+        assert state["queues"] == ["support", "sales"]
+        assert state["queue"] == "support"
+        assert state["is_logged"] is True
+        assert state["paused_queues"] == []
+        assert state["is_paused"] is False
+
+    def test_no_runtime_queues_when_logged_out(self):
+        state = bus_consume._build_agent_state(
+            1, "1001", "John Doe", ["support", "sales"], is_logged=False, is_paused=False
+        )
+        assert state["queues"] == []
+        assert state["queue"] is False
+        assert state["is_logged"] is False
+        assert state["paused_queues"] == []
+
+    def test_paused_queues_seeded_only_when_logged_and_paused(self):
+        state = bus_consume._build_agent_state(
+            1, "1001", "John Doe", ["support", "sales"], is_logged=True, is_paused=True
+        )
+        assert state["paused_queues"] == ["support", "sales"]
+        assert state["is_paused"] is True
+
+    def test_paused_but_logged_out_stays_consistent(self):
+        # is_paused with no runtime membership must not produce a phantom pause.
+        state = bus_consume._build_agent_state(
+            1, "1001", "John Doe", ["support"], is_logged=False, is_paused=True
+        )
+        assert state["queues"] == []
+        assert state["paused_queues"] == []
+        assert state["is_paused"] is False
+
+
+class TestMalformedMemberEvents:
+    """A membership event missing a required field is dropped, not crashed on."""
+
+    def _seed_agent(self, queues):
+        bus_consume.agents[TENANT] = {
+            5: {
+                "id": 5,
+                "number": "1001",
+                "fullname": "John Doe",
+                "queue": queues[0] if queues else False,
+                "queues": list(queues),
+                "paused_queues": [],
+                "is_logged": bool(queues),
+                "is_paused": False,
+            }
+        }
+
+    @pytest.mark.parametrize("event_type", ["QueueMemberAdded", "QueueMemberRemoved"])
+    def test_member_event_without_queue_is_dropped(self, handler, event_type):
+        self._seed_agent(["support"])
+        event = {
+            "Event": event_type,
+            "Membership": "dynamic",
+            "Interface": "Local/id-5@agentcallback",
+            "MemberName": "Agent/1001",
+            # "Queue" intentionally missing
+            "StateInterface": "Local/id-5@agentcallback",
+        }
+
+        # Must not raise (no KeyError) and must leave existing state untouched.
+        handler._agents_status(event, TENANT)
+
+        assert bus_consume.agents[TENANT][5]["queues"] == ["support"]
+        handler.bus_publisher.publish.assert_not_called()
+
+    def test_pause_event_without_paused_is_dropped(self, handler):
+        self._seed_agent(["support"])
+        event = {
+            "Event": "QueueMemberPause",
+            "Membership": "dynamic",
+            "Interface": "Local/id-5@agentcallback",
+            "MemberName": "Agent/1001",
+            "Queue": "support",
+            # "Paused" intentionally missing
+        }
+
+        handler._agents_status(event, TENANT)
+
+        assert bus_consume.agents[TENANT][5]["paused_queues"] == []
+        handler.bus_publisher.publish.assert_not_called()

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -675,6 +675,60 @@ class TestMultiQueueMembership:
         assert agent["is_paused"] is False
 
 
+class TestBootstrapTimestamps:
+    """A REST/restart bootstrap seeds membership but no session timestamps.
+
+    ``get_agents_status`` materialises an already-logged-in (or already-paused)
+    agent with non-empty ``queues`` / ``paused_queues`` but empty ``logged_at``
+    / ``paused_at`` (the real login/pause time is unknown). The first live
+    membership event that arrives afterwards must backfill the missing
+    timestamp instead of treating the agent as "already logged/paused" and
+    leaving the field empty forever.
+    """
+
+    def _bootstrapped_agent(self, queues, paused_queues=None):
+        bus_consume.agents[TENANT] = {
+            5: {
+                "id": 5,
+                "number": "1001",
+                "fullname": "John Doe",
+                "queue": queues[0] if queues else False,
+                "queues": list(queues),
+                "paused_queues": list(paused_queues or []),
+                "is_logged": bool(queues),
+                "is_paused": bool(paused_queues),
+                "is_offline": False,
+                "is_talking": False,
+                "is_ringing": False,
+                # Seeded without timestamps: the real times are unknown.
+                "logged_at": "",
+                "paused_at": "",
+                "talked_at": "",
+                "talked_with_number": "",
+                "talked_with_name": "",
+            }
+        }
+        return bus_consume.agents[TENANT][5]
+
+    def test_member_added_backfills_logged_at_after_bootstrap(self, handler, frozen_now):
+        self._bootstrapped_agent(["support"])
+
+        handler._queue_member_added(_member_added_event("support"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == ["support"]
+        assert agent["logged_at"] == frozen_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+    def test_member_pause_backfills_paused_at_after_bootstrap(self, handler, frozen_now):
+        self._bootstrapped_agent(["support"], paused_queues=["support"])
+
+        handler._queue_member_pause(_member_pause_event("support", paused="1"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["paused_queues"] == ["support"]
+        assert agent["paused_at"] == frozen_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+
 class TestBuildAgentState:
     def test_seeds_runtime_queues_when_logged(self):
         state = bus_consume._build_agent_state(

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.1.0
+version: 2.2.0
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/api.yml
+++ b/wazo_calld_queue/api.yml
@@ -159,11 +159,35 @@ definitions:
   QueueAgentsStatus:
     type: object
     properties:
-      is_loggued:
-        description: Is loggued
+      id:
+        description: Unique identifier of the agent
+        type: integer
+      number:
+        description: Agent number
+        type: string
+      fullname:
+        description: Agent full name
+        type: string
+      queue:
+        description: >-
+          Representative queue (the first of `queues`). Kept for backward
+          compatibility; prefer `queues` for multi-queue agents.
+        type: string
+      queues:
+        description: Names of the queues the agent is currently a member of
+        type: array
+        items:
+          type: string
+      paused_queues:
+        description: Names of the queues in which the agent is currently paused
+        type: array
+        items:
+          type: string
+      is_logged:
+        description: Whether the agent is logged into at least one queue
         type: boolean
       is_paused:
-        description: Is paused
+        description: Whether the agent is paused in at least one queue
         type: boolean
       is_ringing:
         description: Is ringing
@@ -171,11 +195,14 @@ definitions:
       is_talking:
         description: Is talking
         type: boolean
-      loggued_at:
-        description: Loggued at
+      is_offline:
+        description: Whether the agent device is offline (websocket down)
+        type: boolean
+      logged_at:
+        description: Login time of the agent
         type: string
       paused_at:
-        description: Paused at
+        description: Time of the first active pause
         type: string
       talked_at:
         description: Talked at

--- a/wazo_calld_queue/api.yml
+++ b/wazo_calld_queue/api.yml
@@ -190,14 +190,19 @@ definitions:
         description: Whether the agent is paused in at least one queue
         type: boolean
       is_ringing:
-        description: Is ringing
+        description: Whether the agent's device is currently ringing
         type: boolean
       is_talking:
-        description: Is talking
+        description: Whether the agent is currently on a call
         type: boolean
       is_offline:
         description: Whether the agent device is offline (websocket down)
         type: boolean
+      interface:
+        description: >-
+          Asterisk state interface backing the agent's runtime membership
+          (set when the agent joins a queue).
+        type: string
       logged_at:
         description: Login time of the agent
         type: string
@@ -205,13 +210,13 @@ definitions:
         description: Time of the first active pause
         type: string
       talked_at:
-        description: Talked at
+        description: Start time of the agent's current call
         type: string
       talked_with_number:
-        description: Phone number of the caller
+        description: Phone number of the current caller
         type: string
       talked_with_name:
-        description: Name of the caller
+        description: Name of the current caller
         type: string
   QueueAddMember:
     type: object

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -30,6 +30,15 @@ logger = logging.getLogger(__name__)
 AGENT_ID_FROM_IFACE = re.compile(r"^Local/id-(\d+)@agentcallback$")
 MEMBER_NUM_FROM_AGENT = re.compile(r"^Agent/(\d+)$")
 
+# Fields required to safely process each membership-mutating event. A malformed
+# event missing one of these is dropped (and logged) rather than raising a
+# KeyError that would crash the handler and drop the rest of the batch.
+_REQUIRED_EVENT_FIELDS = {
+    "QueueMemberAdded": ("Membership", "Interface", "MemberName", "Queue", "StateInterface"),
+    "QueueMemberRemoved": ("Membership", "Interface", "MemberName", "Queue"),
+    "QueueMemberPause": ("Membership", "Interface", "MemberName", "Queue", "Paused"),
+}
+
 
 def _sync_derived(state):
     """Recompute fields derived from the queue membership sets.
@@ -299,6 +308,18 @@ class QueuesBusEventHandler(object):
     def _agents_status(self, event, tenant_uuid):
         agent = 0
 
+        required = _REQUIRED_EVENT_FIELDS.get(event.get("Event"))
+        if required:
+            missing = [field for field in required if field not in event]
+            if missing:
+                logger.warning(
+                    "Dropping malformed %s event for tenant %s: missing fields %s",
+                    event.get("Event"),
+                    tenant_uuid,
+                    missing,
+                )
+                return
+
         # Check if agents for this tenant exists
         if event["Event"] != "QueueCallerLeave" and event["Membership"] == "dynamic":
             interface = AGENT_ID_FROM_IFACE.match(event["Interface"])
@@ -390,20 +411,35 @@ class QueuesBusEventHandler(object):
             _sync_derived(state)
 
         if event["Event"] == "QueueMemberPause" and event["Membership"] == "dynamic":
-            # Handle pause, tracked per queue (Asterisk pauses per membership)
-            if not agents[tenant_uuid].get(agent):
-                agents[tenant_uuid].update({agent: {}})
+            # Handle pause, tracked per queue (Asterisk pauses per membership).
+            # The agent is always materialised by the membership block above
+            # (add_agent), so a fully-formed state dict is guaranteed here.
             state = agents[tenant_uuid][agent]
+            state.setdefault("queues", [])
             state.setdefault("paused_queues", [])
             was_paused = bool(state["paused_queues"])
             if event["Paused"] == "1":
-                if event["Queue"] not in state["paused_queues"]:
-                    state["paused_queues"].append(event["Queue"])
-                if not was_paused:
-                    # LastPause: set on first pause, kept while any queue paused
-                    state["paused_at"] = datetime.datetime.now().strftime(
-                        "%Y-%m-%dT%H:%M:%S.%f"
+                # Keep the invariant paused_queues ⊆ queues: never report an
+                # agent as paused in a queue it is not a (runtime) member of.
+                # This drops stray pauses that arrive after a QueueMemberRemoved
+                # for the same queue, which would otherwise leave a logged-out
+                # agent flagged as paused.
+                if event["Queue"] not in state["queues"]:
+                    logger.warning(
+                        "Ignoring pause for tenant %s agent %s in queue %s: "
+                        "not a member of that queue",
+                        tenant_uuid,
+                        agent,
+                        event["Queue"],
                     )
+                else:
+                    if event["Queue"] not in state["paused_queues"]:
+                        state["paused_queues"].append(event["Queue"])
+                    if not was_paused:
+                        # LastPause: set on first pause, kept while any queue paused
+                        state["paused_at"] = datetime.datetime.now().strftime(
+                            "%Y-%m-%dT%H:%M:%S.%f"
+                        )
             else:
                 if event["Queue"] in state["paused_queues"]:
                     state["paused_queues"].remove(event["Queue"])

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -31,6 +31,69 @@ AGENT_ID_FROM_IFACE = re.compile(r"^Local/id-(\d+)@agentcallback$")
 MEMBER_NUM_FROM_AGENT = re.compile(r"^Agent/(\d+)$")
 
 
+def _sync_derived(state):
+    """Recompute fields derived from the queue membership sets.
+
+    ``queue`` / ``is_logged`` / ``is_paused`` are never written directly; they
+    always reflect ``queues`` (runtime membership) and ``paused_queues`` so an
+    agent serving several queues stays consistent.
+    """
+    queues = state.setdefault("queues", [])
+    paused_queues = state.setdefault("paused_queues", [])
+    state["queue"] = queues[0] if queues else False
+    state["is_logged"] = bool(queues)
+    state["is_paused"] = bool(paused_queues)
+
+
+def _agent_fullname(info):
+    fullname = ""
+    if str(info["firstname"]) != "None":
+        fullname = str(info["firstname"])
+    if str(info["lastname"]) != "None":
+        fullname += " " + str(info["lastname"])
+    return fullname
+
+
+def _queue_names(info):
+    try:
+        return [q.get("name") for q in info["queues"] if q.get("name")]
+    except (KeyError, TypeError):
+        return []
+
+
+def _build_agent_state(
+    agent_id, number, fullname, configured_queues, is_logged, is_paused
+):
+    """Build a fresh agent state dict.
+
+    ``configured_queues`` is the confd-configured membership. The runtime
+    ``queues`` set is seeded from it only when the agent is logged in, so the
+    derived flags stay consistent; live events keep it up to date afterwards.
+    """
+    runtime_queues = list(configured_queues) if is_logged else []
+    paused_queues = list(runtime_queues) if is_paused else []
+    state = {
+        "id": agent_id,
+        "number": number,
+        "fullname": fullname,
+        "queue": False,
+        "queues": runtime_queues,
+        "paused_queues": paused_queues,
+        "is_logged": False,
+        "is_paused": False,
+        "is_offline": False,
+        "is_talking": False,
+        "is_ringing": False,
+        "logged_at": "",
+        "paused_at": "",
+        "talked_at": "",
+        "talked_with_number": "",
+        "talked_with_name": "",
+    }
+    _sync_derived(state)
+    return state
+
+
 class QueuesBusEventHandler(object):
     def __init__(self, bus_publisher, confd, agentd):
         self.bus_publisher = bus_publisher
@@ -170,12 +233,6 @@ class QueuesBusEventHandler(object):
             agentStatus = self.agentd.agents.get_agent_statuses(tenant_uuid=tenant_uuid)
 
             for agent in agentList["items"]:
-                agent_fullname = ""
-                if str(agent["firstname"]) != "None":
-                    agent_fullname = str(agent["firstname"])
-                if str(agent["lastname"]) != "None":
-                    agent_fullname += " " + str(agent["lastname"])
-
                 status = [
                     x.__dict__
                     for x in agentStatus
@@ -190,31 +247,14 @@ class QueuesBusEventHandler(object):
                 else:
                     agent_ispaused = False
 
-                try:
-                    agent_first_queue = agent["queues"][0].get("name")
-                except (IndexError, KeyError, TypeError):
-                    agent_first_queue = False
-
                 if not agents[tenant_uuid].get(agent["id"]):
-                    agents[tenant_uuid].update(
-                        {
-                            agent["id"]: {
-                                "id": agent["id"],
-                                "number": agent["number"],
-                                "fullname": agent_fullname,
-                                "queue": agent_first_queue,
-                                "is_logged": agent_islogged,
-                                "is_paused": agent_ispaused,
-                                "is_offline": False,
-                                "is_talking": False,
-                                "is_ringing": False,
-                                "logged_at": "",
-                                "paused_at": "",
-                                "talked_at": "",
-                                "talked_with_number": "",
-                                "talked_with_name": "",
-                            }
-                        }
+                    agents[tenant_uuid][agent["id"]] = _build_agent_state(
+                        agent["id"],
+                        agent["number"],
+                        _agent_fullname(agent),
+                        _queue_names(agent),
+                        agent_islogged,
+                        agent_ispaused,
                     )
         logger.debug("agents status for tenant %s: %s", tenant_uuid, agents[tenant_uuid])
         return agents[tenant_uuid]
@@ -224,34 +264,15 @@ class QueuesBusEventHandler(object):
             agentInfo = self.confd.agents.get(
                 resource_or_id=agent, tenant_uuid=tenant_uuid
             )
-            agent_fullname = ""
-            if str(agentInfo["firstname"]) != "None":
-                agent_fullname = str(agentInfo["firstname"])
-            if str(agentInfo["lastname"]) != "None":
-                agent_fullname += " " + str(agentInfo["lastname"])
-            try:
-                agent_first_queue = agentInfo["queues"][0].get("name")
-            except (KeyError, TypeError, IndexError):
-                agent_first_queue = False
-            agents[tenant_uuid].update(
-                {
-                    agent: {
-                        "id": agent,
-                        "number": member,
-                        "fullname": agent_fullname,
-                        "queue": agent_first_queue,
-                        "is_logged": False,
-                        "is_paused": False,
-                        "is_offline": False,
-                        "is_talking": False,
-                        "is_ringing": False,
-                        "logged_at": "",
-                        "paused_at": "",
-                        "talked_at": "",
-                        "talked_with_number": "",
-                        "talked_with_name": "",
-                    }
-                }
+            # Not yet runtime-logged: the triggering membership event populates
+            # ``queues`` right after this call.
+            agents[tenant_uuid][agent] = _build_agent_state(
+                agent,
+                member,
+                _agent_fullname(agentInfo),
+                _queue_names(agentInfo),
+                is_logged=False,
+                is_paused=False,
             )
 
     def get_stats(self, name):
@@ -288,8 +309,6 @@ class QueuesBusEventHandler(object):
                 member = MEMBER_NUM_FROM_AGENT.match(event["MemberName"])
                 member_num = int(member.group(1))
                 self.add_agent(tenant_uuid, agent, member_num)
-            if agents[tenant_uuid][agent]["queue"] != event["Queue"]:
-                agents[tenant_uuid][agent]["queue"] = event["Queue"]
 
         # QueueCallerLeave Get info about call
         if (
@@ -336,37 +355,61 @@ class QueuesBusEventHandler(object):
                 agents[tenant_uuid][agent]["talked_with_name"] = ""
 
         if event["Event"] == "QueueMemberAdded" and event["Membership"] == "dynamic":
-            # Handle connection
-            agents[tenant_uuid][agent]["is_logged"] = True
-            agents[tenant_uuid][agent]["interface"] = event["StateInterface"]
-            agents[tenant_uuid][agent]["logged_at"] = datetime.datetime.now().strftime(
-                "%Y-%m-%dT%H:%M:%S.%f"
-            )  # LoginTime
+            # Handle connection to a queue (an agent may serve several queues)
+            state = agents[tenant_uuid][agent]
+            state.setdefault("queues", [])
+            was_logged = bool(state["queues"])
+            if event["Queue"] not in state["queues"]:
+                state["queues"].append(event["Queue"])
+            state["interface"] = event["StateInterface"]
+            if not was_logged:
+                # LoginTime: set on first queue join, kept across further joins
+                state["logged_at"] = datetime.datetime.now().strftime(
+                    "%Y-%m-%dT%H:%M:%S.%f"
+                )
+            _sync_derived(state)
 
         if event["Event"] == "QueueMemberRemoved" and event["Membership"] == "dynamic":
-            # Handle disconnection
-            agents[tenant_uuid][agent]["is_logged"] = False
-            agents[tenant_uuid][agent]["is_paused"] = False
-            agents[tenant_uuid][agent]["is_talking"] = False
-            agents[tenant_uuid][agent]["is_ringing"] = False
-            agents[tenant_uuid][agent]["logged_at"] = ""
-            agents[tenant_uuid][agent]["paused_at"] = ""
-            agents[tenant_uuid][agent]["talked_at"] = ""
-            agents[tenant_uuid][agent]["talked_with_number"] = ""
-            agents[tenant_uuid][agent]["talked_with_name"] = ""
+            # Handle disconnection from a single queue
+            state = agents[tenant_uuid][agent]
+            state.setdefault("queues", [])
+            state.setdefault("paused_queues", [])
+            if event["Queue"] in state["queues"]:
+                state["queues"].remove(event["Queue"])
+            if event["Queue"] in state["paused_queues"]:
+                state["paused_queues"].remove(event["Queue"])
+            if not state["queues"]:
+                # Fully logged out: reset session/device fields
+                state["is_talking"] = False
+                state["is_ringing"] = False
+                state["logged_at"] = ""
+                state["paused_at"] = ""
+                state["talked_at"] = ""
+                state["talked_with_number"] = ""
+                state["talked_with_name"] = ""
+            _sync_derived(state)
 
         if event["Event"] == "QueueMemberPause" and event["Membership"] == "dynamic":
-            # Handle pause
+            # Handle pause, tracked per queue (Asterisk pauses per membership)
             if not agents[tenant_uuid].get(agent):
                 agents[tenant_uuid].update({agent: {}})
+            state = agents[tenant_uuid][agent]
+            state.setdefault("paused_queues", [])
+            was_paused = bool(state["paused_queues"])
             if event["Paused"] == "1":
-                agents[tenant_uuid][agent]["is_paused"] = True
-                agents[tenant_uuid][agent]["paused_at"] = (
-                    datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
-                )  # LastPause
+                if event["Queue"] not in state["paused_queues"]:
+                    state["paused_queues"].append(event["Queue"])
+                if not was_paused:
+                    # LastPause: set on first pause, kept while any queue paused
+                    state["paused_at"] = datetime.datetime.now().strftime(
+                        "%Y-%m-%dT%H:%M:%S.%f"
+                    )
             else:
-                agents[tenant_uuid][agent]["is_paused"] = False
-                agents[tenant_uuid][agent]["paused_at"] = ""
+                if event["Queue"] in state["paused_queues"]:
+                    state["paused_queues"].remove(event["Queue"])
+                if not state["paused_queues"]:
+                    state["paused_at"] = ""
+            _sync_derived(state)
 
         if agent != 0:
             self._queue_agents_status(agents, tenant_uuid, agent)

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -379,12 +379,14 @@ class QueuesBusEventHandler(object):
             # Handle connection to a queue (an agent may serve several queues)
             state = agents[tenant_uuid][agent]
             state.setdefault("queues", [])
-            was_logged = bool(state["queues"])
             if event["Queue"] not in state["queues"]:
                 state["queues"].append(event["Queue"])
             state["interface"] = event["StateInterface"]
-            if not was_logged:
-                # LoginTime: set on first queue join, kept across further joins
+            if not state.get("logged_at"):
+                # LoginTime: set on first observed queue join, kept across
+                # further joins. Keying on the empty timestamp (rather than on
+                # prior membership) also backfills it after a REST/restart
+                # bootstrap, which seeds ``queues`` but no ``logged_at``.
                 state["logged_at"] = datetime.datetime.now().strftime(
                     "%Y-%m-%dT%H:%M:%S.%f"
                 )
@@ -417,7 +419,6 @@ class QueuesBusEventHandler(object):
             state = agents[tenant_uuid][agent]
             state.setdefault("queues", [])
             state.setdefault("paused_queues", [])
-            was_paused = bool(state["paused_queues"])
             if event["Paused"] == "1":
                 # Keep the invariant paused_queues ⊆ queues: never report an
                 # agent as paused in a queue it is not a (runtime) member of.
@@ -435,8 +436,11 @@ class QueuesBusEventHandler(object):
                 else:
                     if event["Queue"] not in state["paused_queues"]:
                         state["paused_queues"].append(event["Queue"])
-                    if not was_paused:
-                        # LastPause: set on first pause, kept while any queue paused
+                    if not state.get("paused_at"):
+                        # LastPause: set on first observed pause, kept while any
+                        # queue is paused. Keying on the empty timestamp also
+                        # backfills it after a bootstrap that seeds
+                        # ``paused_queues`` but no ``paused_at``.
                         state["paused_at"] = datetime.datetime.now().strftime(
                             "%Y-%m-%dT%H:%M:%S.%f"
                         )


### PR DESCRIPTION
## Résumé

Support des **agents appartenant à plusieurs files d'attente** dans le bridge d'événements `wazo-calld`, plus le durcissement et la documentation associés.

Chaque agent suit désormais sa **membership runtime** (`queues`) et sa **pause par file** (`paused_queues`). Les champs `queue`, `is_logged` et `is_paused` deviennent des valeurs **dérivées**, recalculées via `_sync_derived` à partir des ensembles de membership — ils ne sont jamais écrits directement, ce qui garantit la cohérence d'un agent servant plusieurs files.

Le champ `queue` est conservé (= première file de `queues`) pour la **rétrocompatibilité** ; les clients multi-queue doivent préférer `queues`.

## Changements

### `feat`: support multi-queue
- État agent enrichi : `queues` (membership runtime) et `paused_queues` (pause par file).
- `queue` / `is_logged` / `is_paused` dérivés via `_sync_derived`.
- Corrige : un agent retiré d'une file n'est plus signalé comme déconnecté tant qu'il est membre d'une autre file.
- Corrige : pauser/dépauser dans une file ne bascule plus l'état de pause global.
- Schéma Swagger `QueueAgentsStatus` synchronisé avec le payload réel ; typos `is_loggued` / `loggued_at` → `is_logged` / `logged_at`.
- Bump version plugin `2.2.0`.

### `fix`: durcissement du traitement d'événements
- Les événements `QueueMember*` malformés (champ requis manquant, ex. `Queue`) sont **ignorés avec un warning** au lieu de lever un `KeyError` qui interromprait le batch.
- Invariant `paused_queues ⊆ queues` : une pause sur une file dont l'agent n'est pas membre est ignorée → un agent déconnecté ne peut plus apparaître en pause.
- Suppression du fallback dict-vide redondant dans le handler de pause (l'agent est toujours matérialisé en amont par `add_agent`).
- Champ `interface` documenté + descriptions Swagger affinées.

### `docs`
- `docs/FRONTEND_INTEGRATION.md` : sémantique REST/événements, modèle multi-queue, logique de merge snapshot+subscribe côté client.

## Tests

- `pytest tests/` → **59 passés**.
- Nouveaux scénarios : membership multi-queue (login/logout partiel/total), pause/unpause par file, idempotence (double `Added`/`Pause`), events malformés, invariant `paused_queues ⊆ queues`, seeding de `_build_agent_state`.

```
pytest tests/   # 59 passed
```

## Notes

- État en mémoire : non partagé entre workers, non persistant entre redémarrages (inchangé).
- Multi-tenant : keying par `tenant_uuid` préservé sur tous les nouveaux chemins.
- Suivi (hors périmètre de cette PR) : type hints (si `mypy` en CI) et hygiène des logs DEBUG exposant des données PII/CDR (ticket dédié).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time agent login/pause semantics exposed on REST and websocket events; behavior is well-tested but dashboards must adopt `queues` / `paused_queues` for correct multi-queue UI.
> 
> **Overview**
> **v2.2.0** extends the in-memory agent model so one agent can be logged into several queues at once, with **per-queue pause**, while keeping **`queue` / `is_logged` / `is_paused` derived** via `_sync_derived` from `queues` and `paused_queues` (never written directly).
> 
> `QueueMemberAdded` / `Removed` / `Pause` handling in `bus_consume.py` now updates those sets per queue: partial removal no longer logs the agent out or clears session fields until the **last** queue is left; pause/unpause is scoped per queue. Bootstrap paths use `_build_agent_state` / helpers, and empty `logged_at` / `paused_at` can be **backfilled** on the next live membership event.
> 
> **Hardening:** malformed `QueueMember*` events missing required fields are dropped with a warning; pauses for queues the agent is not in are ignored (`paused_queues ⊆ queues`).
> 
> **API & docs:** `QueueAgentsStatus` in `api.yml` documents `queues`, `paused_queues`, `interface`, fixes `is_logged` / `logged_at` typos; new `docs/FRONTEND_INTEGRATION.md` and `AGENTS.md` updates describe client merge semantics. Extensive `test_bus_consume.py` coverage for multi-queue, bootstrap, and malformed events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe803d13781a0ad2c3a88132b2289a4e7c4d814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->