### PR TITLE
feat: seed bootstrap membership from agentd per-queue status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-06-18
+
+### Changed
+- Bootstrap (`GET /queues/agents_status` and worker startup) now seeds an
+  agent's runtime `queues` / `paused_queues` from `wazo-agentd`'s live per-queue
+  `logged` / `paused` flags, instead of assuming membership in *all* configured
+  queues whenever the agent is logged in. A multi-queue agent's initial snapshot
+  is therefore accurate immediately, rather than over-reporting membership until
+  the next live event. The `paused_queues` ⊆ `queues` invariant is enforced at
+  build time.
+
+### Notes
+- `logged_at` / `paused_at` remain empty after a mid-session bootstrap until the
+  next live membership/pause event: `wazo-agentd` exposes no login/pause
+  timestamp, so an honest "unknown" is preferred over an approximate value.
+
 ## [2.2.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-06-18
+
+### Fixed
+- Backward compatibility of the `queue_agents_status` payload with
+  pre-multi-queue clients (v2.0.x). The legacy `queue` field had started being
+  reset to `false` whenever an agent was logged out; clients that group agents
+  by `agent.queue` (expecting a string) then dropped logged-out agents, and the
+  agents did not reappear on reconnect. `queue` now stays a queue-name string
+  across logout (seeded from the agent's configured/home queue, and never reset
+  on the last `QueueMemberRemoved`); connection state is conveyed by `is_logged`
+  and the runtime `queues` set. The multi-queue fields (`queues`,
+  `paused_queues`) are unchanged.
+
 ## [2.3.0] - 2026-06-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.1] - 2026-06-18
 
+### Changed
+- Internal: `QueueService.livestats` / `agents_status` now delegate to the bus
+  event handler instance (`self.publisher`) instead of calling its methods
+  unbound via the class with `self`. No behaviour change (same clients, same
+  shared state), but it removes a latent `AttributeError` should those handler
+  methods ever use a handler-only attribute.
+
 ### Fixed
 - Backward compatibility of the `queue_agents_status` payload with
   pre-multi-queue clients (v2.0.x). The legacy `queue` field had started being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is therefore accurate immediately, rather than over-reporting membership until
   the next live event. The `paused_queues` ⊆ `queues` invariant is enforced at
   build time.
+- A `QueueMemberRemoved` that references a queue not in the agent's tracked
+  membership is now logged at `WARNING` (previously a silent no-op). This
+  surfaces any drift between the queue name agentd reports at bootstrap and the
+  name carried by live Asterisk events, which would otherwise silently leave an
+  agent flagged as a member of a queue they have left. The matching pause path
+  already logged this case.
 
 ### Notes
 - `logged_at` / `paused_at` remain empty after a mid-session bootstrap until the

--- a/README.md
+++ b/README.md
@@ -1,44 +1,36 @@
 # wazo-calld-queue
 
-Plugin Wazo pour la gestion des files d'attente (queues) via l'API calld et la publication des stats temps réels de files d'attente.
+Plugin Wazo qui ajoute le contrôle des files d'attente à `wazo-calld` (API REST
+`/queues/*`) et publie l'état des queues et des agents en temps réel sur le
+websocket. Le plugin `wazo-call-logd` associé persiste les entrées `queue_log`
+d'Asterisk.
 
-## Description
+## Endpoints
 
-Ce plugin ajoute des fonctionnalités de contrôle des files d'attente à wazo-calld et publie les événements vers le websocket Wazo. Il permet également de gérer les stats temps réels de files d'attente depuis wazo-call-logd.
+Disponibles dans l'API `wazo-calld` (`http://<wazo>/api`, section calld) :
 
-## Fonctionnalités
+| Méthode et route | Description |
+|---|---|
+| `GET /queues` | Liste les files d'attente |
+| `GET /queues/{queue_name}` | Détail d'une file |
+| `PUT /queues/{queue_name}/add_member` | Ajoute un membre |
+| `PUT /queues/{queue_name}/remove_member` | Retire un membre |
+| `PUT /queues/{queue_name}/pause_member` | Met un membre en pause |
+| `GET /queues/{queue_name}/livestats` | Statistiques temps réel |
+| `GET /queues/agents_status` | Statut de tous les agents |
+| `POST /queues/intercept/{queue_name}` | Intercepte un appel en attente |
 
-- **Gestion des files d'attente** : Liste, consultation et contrôle des queues
-- **Statistiques temps réel** : Consultation des stats live des files d'attente
-- **Statut des agents** : Visualisation du statut de tous les agents
-- **Interception d'appels** : Possibilité d'intercepter des appels en queue
-- **Logs des files d'attente** : Publication des événements de queue via websocket
+Un agent peut appartenir à plusieurs files. Pour la sémantique REST/événements
+et l'intégration côté client, voir
+[docs/FRONTEND_INTEGRATION.md](docs/FRONTEND_INTEGRATION.md).
 
 ## Installation
 
 ```bash
-wazo-plugind-cli -c "install git https://github.com/mwolff44/wazo-calld-queue"
+wazo-plugind-cli -c "install git https://github.com/wazo-communication/wazo-calld-queue"
 ```
 
-## Configuration requise
-
-- Wazo version 25.02 ou supérieure
-
-## Utilisation
-
-Une fois installé, les endpoints sont disponibles dans l'API calld de votre Wazo :
-- Consultez la documentation API : `http://votre_wazo/api` (section calld)
-
-### Endpoints principaux
-
-- `GET /queues` - Liste toutes les files d'attente
-- `GET /queues/{queue_name}` - Détails d'une file d'attente
-- `PUT /queues/{queue_name}/add_member` - Ajouter un membre
-- `PUT /queues/{queue_name}/remove_member` - Retirer un membre
-- `PUT /queues/{queue_name}/pause_member` - Mettre en pause un membre
-- `GET /queues/{queue_name}/livestats` - Statistiques temps réel
-- `GET /queues/agents_status` - Statut de tous les agents
-- `POST /queues/{queue_name}/intercept` - Intercepter un appel
+Nécessite Wazo 26.06 ou supérieure.
 
 ## Auteurs
 
@@ -47,8 +39,9 @@ Une fois installé, les endpoints sont disponibles dans l'API calld de votre Waz
 
 ## Licence
 
-Voir le fichier LICENSE pour plus de détails.
+GPL-3.0+. Voir le fichier `LICENSE`.
 
 ## Support
 
-Pour toute question ou problème, ouvrez une issue sur [GitHub](https://github.com/mwolff44/wazo-calld-queue).
+Ouvrez une issue sur
+[GitHub](https://github.com/wazo-communication/wazo-calld-queue/issues).

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -126,7 +126,7 @@ An agent can serve **several queues at once**. Each agent object exposes:
 | `fullname` | string | display name | — |
 | `queues` | string[] | queues the agent is **currently** a member of (runtime) | per-queue |
 | `paused_queues` | string[] | queues in which the agent is **currently paused** | per-queue |
-| `queue` | string \| false | **first** of `queues` — kept for backward compat | derived |
+| `queue` | string \| false | legacy single-queue field — first runtime queue while logged in, else last-known/home queue; **not reset on logout** (back-compat) | derived |
 | `is_logged` | bool | `queues` is non-empty | derived |
 | `is_paused` | bool | `paused_queues` is non-empty | derived |
 | `is_ringing` | bool | the agent's device is ringing | **device** |
@@ -141,10 +141,14 @@ Rules to implement correctly:
 
 - **Use `queues`, not `queue`.** `queue` is only the first element, provided so
   older clients keep working. A multi-queue UI must read `queues`.
-- **`is_logged` / `is_paused` / `queue` are derived — never authoritative on
-  their own.** They are recomputed server-side from `queues` / `paused_queues`.
-  If you mirror this logic client-side, derive the same way:
+- **`is_logged` / `is_paused` are derived — never authoritative on their own.**
+  They are recomputed server-side from `queues` / `paused_queues`. If you mirror
+  this logic client-side, derive the same way:
   `is_logged = queues.length > 0`, `is_paused = paused_queues.length > 0`.
+- **Determine logout from `is_logged` (or empty `queues`), never from `queue`.**
+  `queue` keeps a queue-name string even when the agent is logged out, so that
+  v2.0.x clients that group by `agent.queue` keep working; it is not a logout
+  signal.
 - **Device fields are global, not per-queue.** `is_talking` / `is_ringing` /
   `is_offline` reflect the agent's phone, the same across all their queues.
   Don't render them per queue.
@@ -165,7 +169,7 @@ the agent object; the client just consumes `queue_agents_status`.
 | Log into queue A | `queues += [A]`, `logged_at` set if first | `is_logged: true`, `queue: "A"` |
 | Also log into queue B | `queues += [B]` | `queues: ["A","B"]`, `is_logged` stays true |
 | Remove from queue A only | `queues -= [A]` (also drops A from `paused_queues`) | `queues: ["B"]`, **`is_logged` stays true** |
-| Remove from the last queue | `queues` empties → session reset | `is_logged: false`, `queue: false`, device/session fields cleared |
+| Remove from the last queue | `queues` empties → session reset | `is_logged: false`, `queues: []`, `queue` keeps last name, device/session fields cleared |
 | Pause in queue B | `paused_queues += [B]`, `paused_at` set if first | `is_paused: true` |
 | Unpause queue A (still paused in B) | `paused_queues -= [A]` | `is_paused` stays true |
 | Unpause the last paused queue | `paused_queues` empties | `is_paused: false`, `paused_at: ""` |
@@ -316,8 +320,10 @@ function renderAgent(a) {
   "unknown", not "just now".
 - **`talked_with_*` is populated on `QueueCallerLeave`** (when a caller is
   connected to the agent) and cleared when the call ends.
-- **`queue: false`** means the agent is in no queue (logged out). Handle the
-  boolean-vs-string union.
+- **`queue` is a back-compat string, not a logout signal.** It stays a
+  queue-name string across logout (only `false` if the agent has no configured
+  queue at all). Read `is_logged` / `queues` to know whether the agent is
+  connected. The type is still a `string | false` union — handle both.
 - **Per-worker state:** if your token is load-balanced across workers, a
   `GET /queues/agents_status` may briefly differ from the event stream. Reconcile
   toward the events.

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -306,11 +306,14 @@ function renderAgent(a) {
 
 ## 9. Caveats & edge cases
 
-- **Initial state is best-effort.** On first build from confd, the server does
-  not know per-queue pause or per-queue membership, so it seeds `queues` from
-  the agent's configured queues (only when logged in) and mirrors pause across
-  them. Live events correct this within moments. Don't hard-fail on a brief
-  inconsistency right after startup.
+- **Initial state reflects live per-queue status.** On first build the server
+  reads each agent's current per-queue `logged` / `paused` flags from
+  `wazo-agentd`, so `queues` and `paused_queues` are the queues the agent is
+  actually logged into / paused in — not every configured queue. The only
+  fields it cannot recover at bootstrap are the session timestamps
+  (`logged_at` / `paused_at`), which stay empty until the next live event for
+  that agent (agentd exposes no login/pause time). Treat an empty timestamp as
+  "unknown", not "just now".
 - **`talked_with_*` is populated on `QueueCallerLeave`** (when a caller is
   connected to the agent) and cleared when the call ends.
 - **`queue: false`** means the agent is in no queue (logged out). Handle the

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -776,6 +776,29 @@ class TestLegacyQueueFieldBackCompat:
         assert result[1]["is_logged"] is False
         assert result[1]["queues"] == []
 
+    def test_home_queue_falls_back_to_confd_when_agentd_has_no_status(self, handler):
+        # agentd returns no status for the agent (e.g. never logged in since
+        # agentd started): the home queue must still come from confd, so a
+        # configured agent keeps a queue-name string rather than ``false``.
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {
+                    "id": 1,
+                    "firstname": "John",
+                    "lastname": "Doe",
+                    "number": "1001",
+                    "queues": [{"name": "support"}, {"name": "sales"}],
+                }
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = []
+
+        result = handler.get_agents_status(TENANT)
+
+        assert result[1]["queue"] == "support"
+        assert result[1]["queues"] == []
+        assert result[1]["is_logged"] is False
+
     def test_queue_not_reset_to_false_on_full_logout(self, handler):
         bus_consume.agents[TENANT] = {
             5: bus_consume._build_agent_state(

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -313,7 +313,9 @@ class TestGetAgentsStatus:
         result = handler.get_agents_status(TENANT)
 
         assert result[1]["queues"] == []
-        assert result[1]["queue"] is False
+        # Legacy ``queue`` stays a queue-name string for back-compat; use
+        # ``is_logged`` / ``queues`` for connection state.
+        assert result[1]["queue"] == "support"
         assert result[1]["is_logged"] is False
         assert result[1]["paused_queues"] == []
 
@@ -363,9 +365,10 @@ class TestAddAgent:
         assert agent["id"] == 5
         assert agent["number"] == "1001"
         assert agent["fullname"] == "John Doe"
-        # add_agent starts not-yet-logged: the triggering membership event
-        # populates ``queues`` (and hence the derived ``queue``) right after.
-        assert agent["queue"] is False
+        # add_agent starts not-yet-logged (empty runtime ``queues``) but seeds
+        # the legacy ``queue`` string from the configured queues for back-compat.
+        assert agent["queue"] == "support"
+        assert agent["queues"] == []
         assert agent["is_logged"] is False
 
     def test_initializes_multi_queue(self, handler):
@@ -379,10 +382,10 @@ class TestAddAgent:
         handler.add_agent(TENANT, 5, "1001")
 
         agent = bus_consume.agents[TENANT][5]
-        # add_agent seeds the configured queues but the agent is not yet
-        # runtime-logged, so derived membership starts empty.
+        # Not yet runtime-logged, so derived membership starts empty; the legacy
+        # ``queue`` string is seeded from the first configured queue.
         assert agent["queues"] == []
-        assert agent["queue"] is False
+        assert agent["queue"] == "support"
         assert agent["is_logged"] is False
         assert agent["paused_queues"] == []
 
@@ -588,8 +591,12 @@ class TestMultiQueueMembership:
         handler._queue_member_removed(_member_removed_event("support"))
         assert bus_consume.agents[TENANT][5]["queue"] == "sales"
 
+        # Fully logged out: ``queue`` keeps the last known name (back-compat,
+        # never reset to False); ``is_logged`` / ``queues`` convey the logout.
         handler._queue_member_removed(_member_removed_event("sales"))
-        assert bus_consume.agents[TENANT][5]["queue"] is False
+        assert bus_consume.agents[TENANT][5]["queue"] == "sales"
+        assert bus_consume.agents[TENANT][5]["is_logged"] is False
+        assert bus_consume.agents[TENANT][5]["queues"] == []
 
     def test_pause_in_one_queue_among_two_sets_paused(self, handler):
         self._logged_agent(["support", "sales"])
@@ -742,6 +749,46 @@ class TestBootstrapTimestamps:
         agent = bus_consume.agents[TENANT][5]
         assert agent["paused_queues"] == ["support"]
         assert agent["paused_at"] == frozen_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+
+class TestLegacyQueueFieldBackCompat:
+    """The legacy ``queue`` field must stay a queue-name string even when the
+    agent is logged out.
+
+    The pre-multi-queue front (v2.0.2) groups agents by ``agent.queue`` and
+    expects a string; a boolean ``false`` breaks it. Connection state is carried
+    by ``is_logged`` (and the new ``queues``), not by resetting ``queue``.
+    """
+
+    def test_logged_out_agent_keeps_a_queue_name_at_bootstrap(self, handler):
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {"id": 1, "firstname": "John", "lastname": "Doe", "number": "1001"}
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = [
+            _agentd_status(1, [("support", False, False), ("sales", False, False)]),
+        ]
+
+        result = handler.get_agents_status(TENANT)
+
+        assert result[1]["queue"] == "support"  # truthy, back-compat
+        assert result[1]["is_logged"] is False
+        assert result[1]["queues"] == []
+
+    def test_queue_not_reset_to_false_on_full_logout(self, handler):
+        bus_consume.agents[TENANT] = {
+            5: bus_consume._build_agent_state(
+                5, "1001", "John Doe", ["support"], [], home_queue="support"
+            )
+        }
+
+        handler._queue_member_removed(_member_removed_event("support"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == []
+        assert agent["is_logged"] is False
+        assert agent["queue"] == "support"  # NOT False
 
 
 class TestBuildAgentState:

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -227,6 +227,26 @@ class TestExtractTenantUuid:
             handler._extract_tenant_uuid(event)
 
 
+def _agentd_status(agent_id, queues, logged=None, paused=None):
+    """Build an agentd ``_AgentStatus``-shaped object.
+
+    ``queues`` is a list of ``(name, logged, paused)`` tuples mirroring the
+    real agentd payload, where every configured queue is reported with its
+    current per-queue ``logged`` / ``paused`` flags. The top-level ``logged`` /
+    ``paused`` default to the OR of the per-queue flags, as agentd reports them.
+    """
+    queue_dicts = [
+        {"name": name, "logged": q_logged, "paused": q_paused}
+        for (name, q_logged, q_paused) in queues
+    ]
+    return SimpleNamespace(
+        id=agent_id,
+        logged=any(q[1] for q in queues) if logged is None else logged,
+        paused=any(q[2] for q in queues) if paused is None else paused,
+        queues=queue_dicts,
+    )
+
+
 class TestGetAgentsStatus:
     def test_builds_agents_dict(self, handler):
         handler.confd.agents.list.return_value = {
@@ -236,19 +256,17 @@ class TestGetAgentsStatus:
                     "firstname": "John",
                     "lastname": "Doe",
                     "number": "1001",
-                    "queues": [{"name": "support"}],
                 },
                 {
                     "id": 2,
                     "firstname": "Jane",
                     "lastname": None,
                     "number": "1002",
-                    "queues": [],
                 },
             ]
         }
         handler.agentd.agents.get_agent_statuses.return_value = [
-            SimpleNamespace(id=1, logged=True, paused=False),
+            _agentd_status(1, [("support", True, False)]),
         ]
 
         result = handler.get_agents_status(TENANT)
@@ -257,88 +275,68 @@ class TestGetAgentsStatus:
         assert result[1]["queue"] == "support"
         assert result[1]["is_logged"] is True
         assert result[1]["is_paused"] is False
-        # lastname None is skipped; empty queues -> False; no status -> defaults
+        # lastname None is skipped; no agentd status -> logged-out defaults
         assert result[2]["fullname"] == "Jane"
         assert result[2]["queue"] is False
         assert result[2]["is_logged"] is False
 
-    def test_collects_all_configured_queues(self, handler):
+    def test_seeds_only_queues_the_agent_is_logged_into(self, handler):
+        # Configured for support+sales but only logged into support: runtime
+        # membership must reflect agentd's per-queue flags, not every
+        # configured queue.
         handler.confd.agents.list.return_value = {
             "items": [
-                {
-                    "id": 1,
-                    "firstname": "John",
-                    "lastname": "Doe",
-                    "number": "1001",
-                    "queues": [{"name": "support"}, {"name": "sales"}],
-                }
+                {"id": 1, "firstname": "John", "lastname": "Doe", "number": "1001"}
             ]
         }
         handler.agentd.agents.get_agent_statuses.return_value = [
-            SimpleNamespace(id=1, logged=True, paused=False),
+            _agentd_status(1, [("support", True, False), ("sales", False, False)]),
         ]
 
         result = handler.get_agents_status(TENANT)
 
-        assert result[1]["queues"] == ["support", "sales"]
+        assert result[1]["queues"] == ["support"]
         assert result[1]["queue"] == "support"
         assert result[1]["is_logged"] is True
 
     def test_queues_empty_when_logged_out(self, handler):
         handler.confd.agents.list.return_value = {
             "items": [
-                {
-                    "id": 1,
-                    "firstname": "John",
-                    "lastname": "Doe",
-                    "number": "1001",
-                    "queues": [{"name": "support"}, {"name": "sales"}],
-                }
+                {"id": 1, "firstname": "John", "lastname": "Doe", "number": "1001"}
             ]
         }
         handler.agentd.agents.get_agent_statuses.return_value = [
-            SimpleNamespace(id=1, logged=False, paused=False),
+            _agentd_status(1, [("support", False, False), ("sales", False, False)]),
         ]
 
         result = handler.get_agents_status(TENANT)
 
-        # Runtime membership stays consistent with the logged-out status.
         assert result[1]["queues"] == []
         assert result[1]["queue"] is False
         assert result[1]["is_logged"] is False
         assert result[1]["paused_queues"] == []
 
-    def test_paused_queues_seeded_when_paused(self, handler):
+    def test_seeds_paused_queues_from_per_queue_flags(self, handler):
+        # Logged into support+sales, paused only in sales.
         handler.confd.agents.list.return_value = {
             "items": [
-                {
-                    "id": 1,
-                    "firstname": "John",
-                    "lastname": "Doe",
-                    "number": "1001",
-                    "queues": [{"name": "support"}, {"name": "sales"}],
-                }
+                {"id": 1, "firstname": "John", "lastname": "Doe", "number": "1001"}
             ]
         }
         handler.agentd.agents.get_agent_statuses.return_value = [
-            SimpleNamespace(id=1, logged=True, paused=True),
+            _agentd_status(1, [("support", True, False), ("sales", True, True)]),
         ]
 
         result = handler.get_agents_status(TENANT)
 
-        assert result[1]["paused_queues"] == ["support", "sales"]
+        assert result[1]["queues"] == ["support", "sales"]
+        assert result[1]["paused_queues"] == ["sales"]
         assert result[1]["is_paused"] is True
 
     def test_result_is_cached(self, handler):
         handler.confd.agents.list.return_value = {
             "items": [
-                {
-                    "id": 1,
-                    "firstname": "A",
-                    "lastname": "B",
-                    "number": "1001",
-                    "queues": [{"name": "support"}],
-                }
+                {"id": 1, "firstname": "A", "lastname": "B", "number": "1001"}
             ]
         }
         handler.agentd.agents.get_agent_statuses.return_value = []
@@ -730,36 +728,37 @@ class TestBootstrapTimestamps:
 
 
 class TestBuildAgentState:
-    def test_seeds_runtime_queues_when_logged(self):
+    def test_seeds_runtime_and_paused_queues(self):
         state = bus_consume._build_agent_state(
-            1, "1001", "John Doe", ["support", "sales"], is_logged=True, is_paused=False
+            1, "1001", "John Doe", ["support", "sales"], ["sales"]
         )
         assert state["queues"] == ["support", "sales"]
         assert state["queue"] == "support"
         assert state["is_logged"] is True
-        assert state["paused_queues"] == []
-        assert state["is_paused"] is False
+        assert state["paused_queues"] == ["sales"]
+        assert state["is_paused"] is True
 
-    def test_no_runtime_queues_when_logged_out(self):
-        state = bus_consume._build_agent_state(
-            1, "1001", "John Doe", ["support", "sales"], is_logged=False, is_paused=False
-        )
+    def test_defaults_to_empty_membership(self):
+        state = bus_consume._build_agent_state(1, "1001", "John Doe")
         assert state["queues"] == []
         assert state["queue"] is False
         assert state["is_logged"] is False
         assert state["paused_queues"] == []
+        assert state["is_paused"] is False
 
-    def test_paused_queues_seeded_only_when_logged_and_paused(self):
+    def test_enforces_paused_subset_of_queues(self):
+        # A pause in a queue the agent is not (runtime) a member of must not
+        # produce a phantom paused flag: paused_queues ⊆ queues.
         state = bus_consume._build_agent_state(
-            1, "1001", "John Doe", ["support", "sales"], is_logged=True, is_paused=True
+            1, "1001", "John Doe", ["support"], ["support", "sales"]
         )
-        assert state["paused_queues"] == ["support", "sales"]
+        assert state["queues"] == ["support"]
+        assert state["paused_queues"] == ["support"]
         assert state["is_paused"] is True
 
-    def test_paused_but_logged_out_stays_consistent(self):
-        # is_paused with no runtime membership must not produce a phantom pause.
+    def test_paused_without_membership_stays_consistent(self):
         state = bus_consume._build_agent_state(
-            1, "1001", "John Doe", ["support"], is_logged=False, is_paused=True
+            1, "1001", "John Doe", [], ["support"]
         )
         assert state["queues"] == []
         assert state["paused_queues"] == []

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0+
 
 import datetime
+import logging
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -657,6 +658,22 @@ class TestMultiQueueMembership:
         agent = bus_consume.agents[TENANT][5]
         assert agent["paused_queues"] == []
         assert agent["is_paused"] is False
+
+    def test_member_removed_for_untracked_queue_warns_and_is_noop(
+        self, handler, caplog
+    ):
+        # A removal referencing a queue we are not tracking is a no-op, but it
+        # may signal drift between the agentd bootstrap names and the live
+        # event names, so it must be logged loudly rather than silently ignored.
+        self._logged_agent(["support"])
+
+        with caplog.at_level(logging.WARNING, logger="wazo_calld_queue.bus_consume"):
+            handler._queue_member_removed(_member_removed_event("sales"))
+
+        agent = bus_consume.agents[TENANT][5]
+        assert agent["queues"] == ["support"]
+        assert agent["is_logged"] is True
+        assert "not in tracked membership" in caplog.text
 
     def test_pause_after_removed_does_not_resurrect_membership(self, handler):
         # Removed then a stray Pause for the same queue: the agent is logged out

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from wazo_calld_queue import bus_consume
 from wazo_calld_queue.services import QueueService
 
 
@@ -151,27 +150,17 @@ class TestInterceptCall:
 
 
 class TestStatsDelegation:
-    def test_livestats_returns_queue_stats(self, service):
+    """``QueueService`` delegates stats/agent queries to its bus event handler
+    instance (``self.publisher``), not via an unbound class-method call."""
+
+    def test_livestats_delegates_to_handler(self, service):
         result = service.livestats("support")
 
-        assert result is bus_consume.stats["support"]
-        assert result["count"] == 0
+        service.publisher.get_stats.assert_called_once_with("support")
+        assert result is service.publisher.get_stats.return_value
 
-    def test_agents_status_uses_service_clients(self, service):
-        service.confd.agents.list.return_value = {
-            "items": [
-                {
-                    "id": 1,
-                    "firstname": "John",
-                    "lastname": "Doe",
-                    "number": "1001",
-                    "queues": [{"name": "support"}],
-                }
-            ]
-        }
-        service.agentd.agents.get_agent_statuses.return_value = []
-
+    def test_agents_status_delegates_to_handler(self, service):
         result = service.agents_status("tenant-1")
 
-        assert result[1]["fullname"] == "John Doe"
-        assert result is bus_consume.agents["tenant-1"]
+        service.publisher.get_agents_status.assert_called_once_with("tenant-1")
+        assert result is service.publisher.get_agents_status.return_value

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.3.0
+version: 2.3.1
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.2.0
+version: 2.3.0
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -63,24 +63,40 @@ def _agent_fullname(info):
     return fullname
 
 
-def _queue_names(info):
-    try:
-        return [q.get("name") for q in info["queues"] if q.get("name")]
-    except (KeyError, TypeError):
-        return []
+def _membership_from_status(status):
+    """Derive runtime ``(queues, paused_queues)`` from a live agentd status.
+
+    agentd reports every configured queue with its current per-queue
+    ``logged`` / ``paused`` flags, so the runtime membership is exactly the
+    queues flagged ``logged`` (resp. ``paused``) — not every configured queue.
+    This keeps a multi-queue agent's bootstrap snapshot accurate instead of
+    over-reporting membership until the next live event corrects it.
+    """
+    queues = []
+    paused_queues = []
+    for queue in getattr(status, "queues", None) or []:
+        name = queue.get("name")
+        if not name:
+            continue
+        if queue.get("logged"):
+            queues.append(name)
+        if queue.get("paused"):
+            paused_queues.append(name)
+    return queues, paused_queues
 
 
-def _build_agent_state(
-    agent_id, number, fullname, configured_queues, is_logged, is_paused
-):
+def _build_agent_state(agent_id, number, fullname, queues=None, paused_queues=None):
     """Build a fresh agent state dict.
 
-    ``configured_queues`` is the confd-configured membership. The runtime
-    ``queues`` set is seeded from it only when the agent is logged in, so the
-    derived flags stay consistent; live events keep it up to date afterwards.
+    ``queues`` is the runtime membership (the queues the agent is currently
+    logged into) and ``paused_queues`` the queues it is paused in — both
+    sourced from the live agentd per-queue status at bootstrap. The
+    ``paused_queues ⊆ queues`` invariant is enforced here so a stale pause
+    never produces a phantom paused flag. ``queue`` / ``is_logged`` /
+    ``is_paused`` are derived from these sets via ``_sync_derived``.
     """
-    runtime_queues = list(configured_queues) if is_logged else []
-    paused_queues = list(runtime_queues) if is_paused else []
+    runtime_queues = list(queues or [])
+    paused_queues = [q for q in (paused_queues or []) if q in runtime_queues]
     state = {
         "id": agent_id,
         "number": number,
@@ -242,28 +258,19 @@ class QueuesBusEventHandler(object):
             agentStatus = self.agentd.agents.get_agent_statuses(tenant_uuid=tenant_uuid)
 
             for agent in agentList["items"]:
-                status = [
-                    x.__dict__
-                    for x in agentStatus
-                    if x.__dict__.get("id") == agent["id"]
-                ]
-                if status and status[0].get("logged") is not None:
-                    agent_islogged = status[0].get("logged")
-                else:
-                    agent_islogged = False
-                if status and status[0].get("paused") is not None:
-                    agent_ispaused = status[0].get("paused")
-                else:
-                    agent_ispaused = False
+                status = next(
+                    (s for s in agentStatus if getattr(s, "id", None) == agent["id"]),
+                    None,
+                )
+                runtime_queues, paused_queues = _membership_from_status(status)
 
                 if not agents[tenant_uuid].get(agent["id"]):
                     agents[tenant_uuid][agent["id"]] = _build_agent_state(
                         agent["id"],
                         agent["number"],
                         _agent_fullname(agent),
-                        _queue_names(agent),
-                        agent_islogged,
-                        agent_ispaused,
+                        runtime_queues,
+                        paused_queues,
                     )
         logger.debug("agents status for tenant %s: %s", tenant_uuid, agents[tenant_uuid])
         return agents[tenant_uuid]
@@ -274,14 +281,11 @@ class QueuesBusEventHandler(object):
                 resource_or_id=agent, tenant_uuid=tenant_uuid
             )
             # Not yet runtime-logged: the triggering membership event populates
-            # ``queues`` right after this call.
+            # ``queues`` right after this call, so seed with empty membership.
             agents[tenant_uuid][agent] = _build_agent_state(
                 agent,
                 member,
                 _agent_fullname(agentInfo),
-                _queue_names(agentInfo),
-                is_logged=False,
-                is_paused=False,
             )
 
     def get_stats(self, name):

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -43,13 +43,24 @@ _REQUIRED_EVENT_FIELDS = {
 def _sync_derived(state):
     """Recompute fields derived from the queue membership sets.
 
-    ``queue`` / ``is_logged`` / ``is_paused`` are never written directly; they
-    always reflect ``queues`` (runtime membership) and ``paused_queues`` so an
-    agent serving several queues stays consistent.
+    ``is_logged`` / ``is_paused`` reflect ``queues`` (runtime membership) and
+    ``paused_queues`` so an agent serving several queues stays consistent.
+
+    ``queue`` is the legacy single-queue field kept for backward compatibility
+    with pre-multi-queue clients (v2.0.x), which group agents by ``agent.queue``
+    and expect a queue-name **string**. It tracks the first runtime queue while
+    logged in, but — unlike ``is_logged`` / ``queues`` — it is **never reset to
+    ``False`` on logout**: the last known (or seeded home) queue name is kept so
+    a logged-out agent still carries a string. Use ``is_logged`` / ``queues``,
+    not ``queue``, to determine connection state.
     """
     queues = state.setdefault("queues", [])
     paused_queues = state.setdefault("paused_queues", [])
-    state["queue"] = queues[0] if queues else False
+    if queues:
+        state["queue"] = queues[0]
+    elif not state.get("queue"):
+        state["queue"] = False
+    # else: keep the existing (last-known / home) queue name for back-compat.
     state["is_logged"] = bool(queues)
     state["is_paused"] = bool(paused_queues)
 
@@ -63,37 +74,57 @@ def _agent_fullname(info):
     return fullname
 
 
+def _queue_names(info):
+    """Return the confd-configured queue names for an agent, or ``[]``."""
+    try:
+        return [q.get("name") for q in info["queues"] if q.get("name")]
+    except (KeyError, TypeError):
+        return []
+
+
 def _membership_from_status(status):
-    """Derive runtime ``(queues, paused_queues)`` from a live agentd status.
+    """Derive ``(queues, paused_queues, all_queues)`` from a live agentd status.
 
     agentd reports every configured queue with its current per-queue
     ``logged`` / ``paused`` flags, so the runtime membership is exactly the
     queues flagged ``logged`` (resp. ``paused``) — not every configured queue.
     This keeps a multi-queue agent's bootstrap snapshot accurate instead of
     over-reporting membership until the next live event corrects it.
+
+    ``all_queues`` is every queue the agent is configured for (regardless of
+    login), used to seed the legacy ``queue`` field so a logged-out agent still
+    carries a queue-name string (see ``_sync_derived``).
     """
     queues = []
     paused_queues = []
+    all_queues = []
     for queue in getattr(status, "queues", None) or []:
         name = queue.get("name")
         if not name:
             continue
+        all_queues.append(name)
         if queue.get("logged"):
             queues.append(name)
         if queue.get("paused"):
             paused_queues.append(name)
-    return queues, paused_queues
+    return queues, paused_queues, all_queues
 
 
-def _build_agent_state(agent_id, number, fullname, queues=None, paused_queues=None):
+def _build_agent_state(
+    agent_id, number, fullname, queues=None, paused_queues=None, home_queue=False
+):
     """Build a fresh agent state dict.
 
     ``queues`` is the runtime membership (the queues the agent is currently
     logged into) and ``paused_queues`` the queues it is paused in — both
     sourced from the live agentd per-queue status at bootstrap. The
     ``paused_queues ⊆ queues`` invariant is enforced here so a stale pause
-    never produces a phantom paused flag. ``queue`` / ``is_logged`` /
-    ``is_paused`` are derived from these sets via ``_sync_derived``.
+    never produces a phantom paused flag. ``is_logged`` / ``is_paused`` are
+    derived from these sets via ``_sync_derived``.
+
+    ``home_queue`` seeds the legacy ``queue`` field (kept for v2.0.x clients)
+    so a logged-out agent still carries a queue-name string rather than
+    ``False``; when logged in, ``queue`` tracks the first runtime queue.
     """
     runtime_queues = list(queues or [])
     paused_queues = [q for q in (paused_queues or []) if q in runtime_queues]
@@ -101,7 +132,7 @@ def _build_agent_state(agent_id, number, fullname, queues=None, paused_queues=No
         "id": agent_id,
         "number": number,
         "fullname": fullname,
-        "queue": False,
+        "queue": home_queue or False,
         "queues": runtime_queues,
         "paused_queues": paused_queues,
         "is_logged": False,
@@ -262,7 +293,10 @@ class QueuesBusEventHandler(object):
                     (s for s in agentStatus if getattr(s, "id", None) == agent["id"]),
                     None,
                 )
-                runtime_queues, paused_queues = _membership_from_status(status)
+                runtime_queues, paused_queues, all_queues = _membership_from_status(
+                    status
+                )
+                home_queue = all_queues[0] if all_queues else False
 
                 if not agents[tenant_uuid].get(agent["id"]):
                     agents[tenant_uuid][agent["id"]] = _build_agent_state(
@@ -271,6 +305,7 @@ class QueuesBusEventHandler(object):
                         _agent_fullname(agent),
                         runtime_queues,
                         paused_queues,
+                        home_queue,
                     )
         logger.debug("agents status for tenant %s: %s", tenant_uuid, agents[tenant_uuid])
         return agents[tenant_uuid]
@@ -282,10 +317,14 @@ class QueuesBusEventHandler(object):
             )
             # Not yet runtime-logged: the triggering membership event populates
             # ``queues`` right after this call, so seed with empty membership.
+            # ``home_queue`` seeds the legacy ``queue`` string from the
+            # confd-configured queues (matches the pre-multi-queue behaviour).
+            configured = _queue_names(agentInfo)
             agents[tenant_uuid][agent] = _build_agent_state(
                 agent,
                 member,
                 _agent_fullname(agentInfo),
+                home_queue=configured[0] if configured else False,
             )
 
     def get_stats(self, name):

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -403,6 +403,21 @@ class QueuesBusEventHandler(object):
             state.setdefault("paused_queues", [])
             if event["Queue"] in state["queues"]:
                 state["queues"].remove(event["Queue"])
+            else:
+                # No-op removal: either a duplicate/late event, or the queue
+                # name in this live event does not match the one agentd
+                # reported at bootstrap. Log it loudly so a silent drift
+                # between the two namespaces is surfaced rather than leaving
+                # the agent wrongly flagged as a member of that queue.
+                logger.warning(
+                    "QueueMemberRemoved for tenant %s agent %s in queue %s: "
+                    "not in tracked membership %s (duplicate event or a "
+                    "queue-name mismatch between agentd bootstrap and events)",
+                    tenant_uuid,
+                    agent,
+                    event["Queue"],
+                    state["queues"],
+                )
             if event["Queue"] in state["paused_queues"]:
                 state["paused_queues"].remove(event["Queue"])
             if not state["queues"]:

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -296,7 +296,11 @@ class QueuesBusEventHandler(object):
                 runtime_queues, paused_queues, all_queues = _membership_from_status(
                     status
                 )
-                home_queue = all_queues[0] if all_queues else False
+                # Seed the legacy ``queue`` from agentd's queue list, falling
+                # back to confd when agentd has no status (or no queues) for the
+                # agent, so a configured agent never gets ``queue: false``.
+                home_queues = all_queues or _queue_names(agent)
+                home_queue = home_queues[0] if home_queues else False
 
                 if not agents[tenant_uuid].get(agent["id"]):
                     agents[tenant_uuid][agent["id"]] = _build_agent_state(

--- a/wazo_calld_queue/services.py
+++ b/wazo_calld_queue/services.py
@@ -1,8 +1,6 @@
 # Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
-from .bus_consume import QueuesBusEventHandler
-
 
 class QueueService(object):
     def __init__(self, amid, confd, ari, agentd, publisher):
@@ -56,10 +54,10 @@ class QueueService(object):
         return self.amid.action("queuepause", pause_member)
 
     def livestats(self, queue_name):
-        return QueuesBusEventHandler.get_stats(self, queue_name)
+        return self.publisher.get_stats(queue_name)
 
     def agents_status(self, tenant_uuid):
-        return QueuesBusEventHandler.get_agents_status(self, tenant_uuid)
+        return self.publisher.get_agents_status(tenant_uuid)
 
     def _queues(self, queue):
         return {


### PR DESCRIPTION
## Résumé

Au **bootstrap** (`GET /queues/agents_status` et démarrage worker), la membership runtime d'un agent était devinée : `_build_agent_state` seedait `queues` à partir de **toutes les files configurées dans confd** dès que l'agent était loggué, et recopiait une pause globale sur toutes. Pour un agent multi-files, ça **sur-déclarait** la membership (et la pause) jusqu'à ce qu'un event live corrige l'état.

Or `wazo-agentd` expose déjà l'info exacte. `get_agent_statuses()` → `GET /agents` (`status_all`) renvoie, pour chaque agent, la liste `queues` avec un flag `logged` / `paused` **par file** (`_AgentStatus.queues`). On seed donc `queues` / `paused_queues` directement à partir de ces flags : le snapshot initial reflète les files où l'agent est **réellement** loggué / en pause.

## Changements

### `feat`: seed multi-files depuis l'état live agentd
- `get_agents_status` corrèle chaque agent confd (pour `fullname` / `number`) avec son statut agentd et dérive la membership via le nouvel helper `_membership_from_status` (files où `logged` / `paused`).
- `_build_agent_state(agent_id, number, fullname, queues=None, paused_queues=None)` : la membership runtime est passée explicitement par l'appelant ; l'invariant `paused_queues ⊆ queues` est **garanti à la construction**.
- Suppression de l'helper mort `_queue_names` (membership confd-configurée), `add_agent` seede désormais une membership vide (l'event déclencheur peuple `queues` juste après — inchangé).
- Bump version plugin `2.3.0`.

## Périmètre / non couvert

- **`logged_at` / `paused_at` au bootstrap** : agentd n'expose **aucun timestamp** de login/pause (vérifié sur capture live : champs `id, number, logged, paused, paused_reason, extension, context, state_interface, queues[]` — pas de date). Ils restent donc vides jusqu'au prochain event live (backfill ajouté précédemment dans #7). Un "inconnu" honnête est préféré à une valeur approximative (= heure de redémarrage). Documenté dans `docs/FRONTEND_INTEGRATION.md` §9.

## Tests

- `pytest tests/` → **61 passés**.
- `TestGetAgentsStatus` réécrit pour des statuts agentd réalistes (flags par file) ; nouveaux cas : seed uniquement des files `logged`, `paused_queues` par file, agent loggué-déconnecté.
- `TestBuildAgentState` : nouvelle signature, invariant `paused_queues ⊆ queues`, pause sans membership ignorée.

## Notes

- État en mémoire : non partagé entre workers, non persistant entre redémarrages (inchangé).
- Multi-tenant : keying par `tenant_uuid` préservé.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time agent payload semantics (bootstrap accuracy and legacy `queue` behavior) that older frontends depend on; core event handling is well covered by tests but production clients must use `is_logged`/`queues` for logout.
> 
> **Overview**
> **Agent bootstrap** for `GET /queues/agents_status` now builds runtime `queues` / `paused_queues` from **wazo-agentd** per-queue `logged` / `paused` flags (via `_membership_from_status`), instead of treating all confd-configured queues as joined when the agent is globally logged in. `_build_agent_state` takes explicit membership lists and enforces `paused_queues ⊆ queues`.
> 
> **Legacy `queue` back-compat (v2.0.x):** `_sync_derived` no longer sets `queue` to `false` on full logout—it keeps the last runtime or **home** queue name (seeded from agentd/confd through `home_queue`). Connection state stays on `is_logged` / `queues`. `add_agent` seeds that home string while runtime `queues` stay empty until events arrive.
> 
> **Ops / wiring:** untracked `QueueMemberRemoved` queues log at **WARNING**; `QueueService.livestats` / `agents_status` call **`self.publisher`** instead of unbound handler methods. Docs, changelog, and tests updated; plugin **2.3.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041b3d9cd4d1db761d756a6df4899a5b2426337e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Mise à jour — fix rétrocompat `queue` (2.3.1)

Cette PR embarque aussi un correctif de **rétrocompatibilité du payload** `queue_agents_status` avec les clients pré-multi-files (v2.0.x), suite à un bug remonté en prod.

**Symptôme :** un agent déconnecté n'apparaissait plus dans la liste du front, et ne réapparaissait pas à la reconnexion.

**Cause :** depuis 2.2.0, le champ legacy `queue` était dérivé en `queues[0] if queues else False` → un agent déconnecté publiait `queue: false`. Les fronts v2.0.x groupent les agents par `agent.queue` (attendu : une chaîne) : un `false` booléen fait disparaître l'agent, et l'entrée snapshot inutilisable empêche les events live suivants de le réafficher.

**Correctif :** `queue` redevient conforme à v2.0.2 — toujours une chaîne (nom de file), **jamais remis à `false` à la déconnexion**. Il suit la première file runtime quand l'agent est loggué, sinon conserve la dernière file connue / la file « home » (seedée via le nouvel argument `home_queue` de `_build_agent_state`). L'état de connexion se lit sur `is_logged` / `queues`. Les champs multi-files (`queues`, `paused_queues`) sont inchangés.

- `pytest tests/` → **64 passés** (nouveaux : `TestLegacyQueueFieldBackCompat`).
- `docs/FRONTEND_INTEGRATION.md` mis à jour (sémantique `queue`, table des champs, §9).
- Version plugin **2.3.1**.
