### PR TITLE
fix: thread-safe, instance-owned real-time state (#11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,27 @@ Version source: `wazo/plugin.yml`.
 
 - Map REST API calls to Asterisk Manager Interface actions.
 - Consume `QueueCaller*` and `QueueMember*` bus events in `bus_consume.py`.
-- Maintain global in-memory dicts: `stats` and `agents`.
-- An agent may serve several queues: each `agents[tenant][id]` tracks runtime
-  membership in `queues` and per-queue pause in `paused_queues`; `queue`,
-  `is_logged`, and `is_paused` are derived from these via `_sync_derived` and
-  never written directly.
+- Maintain the in-memory state `self._stats` and `self._agents`, owned by the
+  `QueuesBusEventHandler` instance (not module globals) and guarded by a
+  reentrant `self._lock`. `wazo-calld` runs as a **single process** with a
+  cheroot thread pool (`max_threads`, default 10): the bus consumer thread
+  mutates this state while REST worker threads read and lazily seed it, so the
+  same dict is shared by every thread and **every access must hold `_lock`**.
+  The state methods (`get_agents_status`, `get_stats`, `add_agent`,
+  `_agents_status`, `_livestats`) take the lock; the heavy ones delegate to a
+  `*_locked` helper so the body need not re-indent.
+- An agent may serve several queues: each `self._agents[tenant][id]` tracks
+  runtime membership in `queues` and per-queue pause in `paused_queues`;
+  `queue`, `is_logged`, and `is_paused` are derived from these via
+  `_sync_derived` and never written directly.
 - Republish enriched events to the front-end websocket.
-- Treat in-memory state as non-shared across workers and non-persistent across restarts.
+- In-memory state is **not persisted across restarts**: `agents` is rebuilt
+  lazily from agentd/confd on demand (session timestamps stay empty until the
+  next live event); `stats` are live counters, intentionally ephemeral (they
+  also self-reset when the day changes). For durable queue history use the
+  `wazo_call_logd_queue` plugin (`queue_log`), not this state. Because
+  `wazo-calld` is single-process, REST and the event stream read the **same**
+  state — there is no cross-worker divergence to reconcile (see issue #11).
 - Resolve tenant UUID from `WAZO_TENANT_UUID` or confd via `_extract_tenant_uuid`.
 
 ## Conventions

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -16,17 +16,22 @@ explains the **semantics** you must respect to implement a correct client.
 
 ## 1. Mental model
 
-The server keeps **in-memory, per-worker, non-persistent** state:
+The server keeps **in-memory, non-persistent** state:
 
 - `stats[queue_name]` — live counters per queue.
 - `agents[tenant_uuid][agent_id]` — live status per agent.
 
+This state lives in a single `wazo-calld` process (a cheroot thread pool), so
+REST calls and the event stream read the **same** state — there is no
+cross-worker divergence. It is, however, **not durable**.
+
 Two consequences for the client:
 
 1. **Never treat the server as a durable source of truth.** State is rebuilt
-   from Asterisk events after a restart and is **not shared across workers**, so
-   two REST calls may hit different workers with slightly different snapshots.
-   Trust the live event stream, not repeated polling.
+   from Asterisk events / agentd after a restart, so it can be incomplete right
+   after a reload (e.g. session timestamps are empty until the next live event,
+   and `stats` counters restart from zero). Trust the live event stream, not
+   repeated polling.
 2. The correct pattern is **snapshot + subscribe**:
    1. `GET` the REST endpoint once to bootstrap (full map).
    2. Subscribe to the matching bus/websocket event for incremental updates.
@@ -324,6 +329,9 @@ function renderAgent(a) {
   queue-name string across logout (only `false` if the agent has no configured
   queue at all). Read `is_logged` / `queues` to know whether the agent is
   connected. The type is still a `string | false` union — handle both.
-- **Per-worker state:** if your token is load-balanced across workers, a
-  `GET /queues/agents_status` may briefly differ from the event stream. Reconcile
-  toward the events.
+- **State is shared in-process, not durable.** `wazo-calld` is single-process,
+  so a `GET /queues/agents_status` and the event stream read the same state —
+  no cross-worker divergence to reconcile. But after a `wazo-calld` restart the
+  bootstrap is rebuilt from agentd/confd: `agents` come back without session
+  timestamps (empty until the next live event) and `stats` counters restart
+  from zero. Re-`GET` to bootstrap after a reconnect, then trust the events.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,18 +92,7 @@ _install_wazo_bus_stub()
 _install_wazo_calld_stub()
 
 # Imported only after the stub is in place.
-from wazo_calld_queue import bus_consume  # noqa: E402
 from wazo_calld_queue.bus_consume import QueuesBusEventHandler  # noqa: E402
-
-
-@pytest.fixture(autouse=True)
-def reset_module_state():
-    """Reset the module-level ``stats`` / ``agents`` caches around each test."""
-    bus_consume.stats.clear()
-    bus_consume.agents.clear()
-    yield
-    bus_consume.stats.clear()
-    bus_consume.agents.clear()
 
 
 @pytest.fixture

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -3,6 +3,7 @@
 
 import datetime
 import logging
+import threading
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -63,6 +64,16 @@ def _member_removed_event(queue, agent_id=5, member="1001", tenant=TENANT):
     }
 
 
+def _leave_event(uniqueid, queue="support", count="0", tenant=TENANT):
+    return {
+        "Event": "QueueCallerLeave",
+        "Queue": queue,
+        "Context": "queue",
+        "Count": count,
+        "Uniqueid": uniqueid,
+    }
+
+
 def _member_pause_event(queue, paused, agent_id=5, member="1001", tenant=TENANT):
     return {
         "Event": "QueueMemberPause",
@@ -112,7 +123,7 @@ class TestGetStats:
         assert result["awr"] == 0
         assert result["waiting_calls"] == []
         assert result["updated_at"] == frozen_now.day
-        assert bus_consume.stats["support"] is result
+        assert handler._stats["support"] is result
 
     def test_returns_existing_entry_same_day(self, handler):
         first = handler.get_stats("support")
@@ -140,7 +151,7 @@ class TestLiveStats:
     def test_caller_join_tracks_waiting_call(self, handler):
         handler._livestats(_join_event("111", count="1"), TENANT)
 
-        stats = bus_consume.stats["support"]
+        stats = handler._stats["support"]
         assert stats["count"] == 1
         assert stats["count_color"] == "green"
         assert len(stats["waiting_calls"]) == 1
@@ -150,7 +161,7 @@ class TestLiveStats:
     def test_caller_join_count_color_turns_red_above_one(self, handler):
         handler._livestats(_join_event("111", count="2"), TENANT)
 
-        assert bus_consume.stats["support"]["count_color"] == "red"
+        assert handler._stats["support"]["count_color"] == "red"
 
     def test_caller_leave_updates_counters(self, handler):
         handler._livestats(_join_event("111", count="1"), TENANT)
@@ -163,7 +174,7 @@ class TestLiveStats:
 
         handler._livestats(leave, TENANT)
 
-        stats = bus_consume.stats["support"]
+        stats = handler._stats["support"]
         assert stats["answered"] == 1
         assert stats["received"] == 1
         assert stats["awr"] == 100
@@ -179,7 +190,7 @@ class TestLiveStats:
         }
         handler._livestats(abandon, TENANT)
 
-        stats = bus_consume.stats["support"]
+        stats = handler._stats["support"]
         assert stats["abandonned"] == 1
         assert stats["waiting_calls"] == []
 
@@ -196,7 +207,7 @@ class TestLiveStats:
         }
         handler._livestats(abandon_b, TENANT)
 
-        remaining = [c["uniqueid"] for c in bus_consume.stats["support"]["waiting_calls"]]
+        remaining = [c["uniqueid"] for c in handler._stats["support"]["waiting_calls"]]
         assert remaining == ["A", "C"]
 
     def test_publishes_livestats_event(self, handler):
@@ -352,7 +363,7 @@ class TestGetAgentsStatus:
 
 class TestAddAgent:
     def test_adds_missing_agent_from_confd(self, handler):
-        bus_consume.agents[TENANT] = {}
+        handler._agents[TENANT] = {}
         handler.confd.agents.get.return_value = {
             "firstname": "John",
             "lastname": "Doe",
@@ -361,7 +372,7 @@ class TestAddAgent:
 
         handler.add_agent(TENANT, 5, "1001")
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["id"] == 5
         assert agent["number"] == "1001"
         assert agent["fullname"] == "John Doe"
@@ -372,7 +383,7 @@ class TestAddAgent:
         assert agent["is_logged"] is False
 
     def test_initializes_multi_queue(self, handler):
-        bus_consume.agents[TENANT] = {}
+        handler._agents[TENANT] = {}
         handler.confd.agents.get.return_value = {
             "firstname": "John",
             "lastname": "Doe",
@@ -381,7 +392,7 @@ class TestAddAgent:
 
         handler.add_agent(TENANT, 5, "1001")
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         # Not yet runtime-logged, so derived membership starts empty; the legacy
         # ``queue`` string is seeded from the first configured queue.
         assert agent["queues"] == []
@@ -390,11 +401,11 @@ class TestAddAgent:
         assert agent["paused_queues"] == []
 
     def test_does_not_overwrite_existing_agent(self, handler):
-        bus_consume.agents[TENANT] = {5: {"id": 5, "fullname": "Existing"}}
+        handler._agents[TENANT] = {5: {"id": 5, "fullname": "Existing"}}
 
         handler.add_agent(TENANT, 5, "1001")
 
-        assert bus_consume.agents[TENANT][5]["fullname"] == "Existing"
+        assert handler._agents[TENANT][5]["fullname"] == "Existing"
         handler.confd.agents.get.assert_not_called()
 
 
@@ -436,7 +447,7 @@ class TestMemberEventHandlers:
         assert published[0].tenant_uuid == ZERO_UUID
 
     def test_member_pause_sets_paused_and_publishes_status(self, handler):
-        bus_consume.agents[TENANT] = {
+        handler._agents[TENANT] = {
             5: {
                 "id": 5,
                 "number": "1001",
@@ -459,7 +470,7 @@ class TestMemberEventHandlers:
 
         handler._queue_member_pause(event)
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["is_paused"] is True
         assert agent["paused_at"] != ""
 
@@ -468,7 +479,7 @@ class TestMemberEventHandlers:
         assert published[0].content == agent
 
     def test_member_status_talking_updates_agent(self, handler):
-        bus_consume.agents[TENANT] = {
+        handler._agents[TENANT] = {
             5: {
                 "id": 5,
                 "number": "1001",
@@ -492,7 +503,7 @@ class TestMemberEventHandlers:
 
         handler._queue_member_status(event)
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["is_talking"] is True
         assert agent["is_ringing"] is False
         assert agent["talked_at"] != ""
@@ -514,16 +525,16 @@ class TestCallerEventHandlers:
 
         handler._queue_caller_join(event)
 
-        assert "support" not in bus_consume.stats
+        assert "support" not in handler._stats
         published = _published_events(handler)
         assert len(published) == 1
         assert isinstance(published[0], QueueCallerJoinEvent)
 
 
 class TestMultiQueueMembership:
-    def _logged_agent(self, queues, paused_queues=None):
+    def _logged_agent(self, handler, queues, paused_queues=None):
         """Seed an agent already logged into ``queues`` (runtime membership)."""
-        bus_consume.agents[TENANT] = {
+        handler._agents[TENANT] = {
             5: {
                 "id": 5,
                 "number": "1001",
@@ -543,37 +554,37 @@ class TestMultiQueueMembership:
                 "talked_with_name": "",
             }
         }
-        return bus_consume.agents[TENANT][5]
+        return handler._agents[TENANT][5]
 
     def test_member_added_to_second_queue_keeps_both(self, handler):
-        self._logged_agent(["support"])
+        self._logged_agent(handler, ["support"])
 
         handler._queue_member_added(_member_added_event("sales"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == ["support", "sales"]
         assert agent["is_logged"] is True
 
     def test_member_removed_from_one_queue_stays_logged(self, handler):
-        self._logged_agent(["support", "sales"])
+        self._logged_agent(handler, ["support", "sales"])
 
         handler._queue_member_removed(_member_removed_event("sales"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == ["support"]
         assert agent["is_logged"] is True
         # Session is preserved while still member of another queue.
         assert agent["logged_at"] == "2026-06-17T12:00:00.000000"
 
     def test_member_removed_from_last_queue_logs_out(self, handler):
-        agent = self._logged_agent(["support"])
+        agent = self._logged_agent(handler, ["support"])
         agent["is_talking"] = True
         agent["talked_at"] = "2026-06-17T12:30:00.000000"
         agent["talked_with_number"] = "2000"
 
         handler._queue_member_removed(_member_removed_event("support"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == []
         assert agent["is_logged"] is False
         assert agent["is_talking"] is False
@@ -583,74 +594,74 @@ class TestMultiQueueMembership:
         assert agent["talked_with_number"] == ""
 
     def test_queue_field_is_first_of_queues(self, handler):
-        self._logged_agent(["support"])
+        self._logged_agent(handler, ["support"])
 
         handler._queue_member_added(_member_added_event("sales"))
-        assert bus_consume.agents[TENANT][5]["queue"] == "support"
+        assert handler._agents[TENANT][5]["queue"] == "support"
 
         handler._queue_member_removed(_member_removed_event("support"))
-        assert bus_consume.agents[TENANT][5]["queue"] == "sales"
+        assert handler._agents[TENANT][5]["queue"] == "sales"
 
         # Fully logged out: ``queue`` keeps the last known name (back-compat,
         # never reset to False); ``is_logged`` / ``queues`` convey the logout.
         handler._queue_member_removed(_member_removed_event("sales"))
-        assert bus_consume.agents[TENANT][5]["queue"] == "sales"
-        assert bus_consume.agents[TENANT][5]["is_logged"] is False
-        assert bus_consume.agents[TENANT][5]["queues"] == []
+        assert handler._agents[TENANT][5]["queue"] == "sales"
+        assert handler._agents[TENANT][5]["is_logged"] is False
+        assert handler._agents[TENANT][5]["queues"] == []
 
     def test_pause_in_one_queue_among_two_sets_paused(self, handler):
-        self._logged_agent(["support", "sales"])
+        self._logged_agent(handler, ["support", "sales"])
 
         handler._queue_member_pause(_member_pause_event("sales", paused="1"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["paused_queues"] == ["sales"]
         assert agent["is_paused"] is True
         assert agent["paused_at"] != ""
 
     def test_unpause_one_of_two_paused_queues_stays_paused(self, handler):
-        agent = self._logged_agent(["support", "sales"])
+        agent = self._logged_agent(handler, ["support", "sales"])
         agent["paused_queues"] = ["support", "sales"]
         agent["is_paused"] = True
         agent["paused_at"] = "2026-06-17T12:15:00.000000"
 
         handler._queue_member_pause(_member_pause_event("support", paused="0"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["paused_queues"] == ["sales"]
         assert agent["is_paused"] is True
         assert agent["paused_at"] == "2026-06-17T12:15:00.000000"
 
     def test_unpause_last_queue_clears_paused(self, handler):
-        agent = self._logged_agent(["support"])
+        agent = self._logged_agent(handler, ["support"])
         agent["paused_queues"] = ["support"]
         agent["is_paused"] = True
         agent["paused_at"] = "2026-06-17T12:15:00.000000"
 
         handler._queue_member_pause(_member_pause_event("support", paused="0"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["paused_queues"] == []
         assert agent["is_paused"] is False
         assert agent["paused_at"] == ""
 
     def test_duplicate_added_event_is_idempotent(self, handler):
-        self._logged_agent(["support"])
+        self._logged_agent(handler, ["support"])
 
         handler._queue_member_added(_member_added_event("support"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == ["support"]
 
     def test_duplicate_pause_event_is_idempotent(self, handler):
-        agent = self._logged_agent(["support"])
+        agent = self._logged_agent(handler, ["support"])
         agent["paused_queues"] = ["support"]
         agent["is_paused"] = True
         agent["paused_at"] = "2026-06-17T12:15:00.000000"
 
         handler._queue_member_pause(_member_pause_event("support", paused="1"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["paused_queues"] == ["support"]
         # Already paused: the first-pause timestamp must be preserved.
         assert agent["paused_at"] == "2026-06-17T12:15:00.000000"
@@ -658,11 +669,11 @@ class TestMultiQueueMembership:
     def test_pause_in_non_member_queue_is_ignored(self, handler):
         # Agent is a member of "support" only; a pause for "sales" is dropped to
         # keep the invariant paused_queues ⊆ queues.
-        self._logged_agent(["support"])
+        self._logged_agent(handler, ["support"])
 
         handler._queue_member_pause(_member_pause_event("sales", paused="1"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["paused_queues"] == []
         assert agent["is_paused"] is False
 
@@ -672,12 +683,12 @@ class TestMultiQueueMembership:
         # A removal referencing a queue we are not tracking is a no-op, but it
         # may signal drift between the agentd bootstrap names and the live
         # event names, so it must be logged loudly rather than silently ignored.
-        self._logged_agent(["support"])
+        self._logged_agent(handler, ["support"])
 
         with caplog.at_level(logging.WARNING, logger="wazo_calld_queue.bus_consume"):
             handler._queue_member_removed(_member_removed_event("sales"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == ["support"]
         assert agent["is_logged"] is True
         assert "not in tracked membership" in caplog.text
@@ -685,12 +696,12 @@ class TestMultiQueueMembership:
     def test_pause_after_removed_does_not_resurrect_membership(self, handler):
         # Removed then a stray Pause for the same queue: the agent is logged out
         # and must not be reported as paused.
-        self._logged_agent(["support"])
+        self._logged_agent(handler, ["support"])
 
         handler._queue_member_removed(_member_removed_event("support"))
         handler._queue_member_pause(_member_pause_event("support", paused="1"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == []
         assert agent["paused_queues"] == []
         assert agent["is_logged"] is False
@@ -708,8 +719,8 @@ class TestBootstrapTimestamps:
     leaving the field empty forever.
     """
 
-    def _bootstrapped_agent(self, queues, paused_queues=None):
-        bus_consume.agents[TENANT] = {
+    def _bootstrapped_agent(self, handler, queues, paused_queues=None):
+        handler._agents[TENANT] = {
             5: {
                 "id": 5,
                 "number": "1001",
@@ -730,23 +741,23 @@ class TestBootstrapTimestamps:
                 "talked_with_name": "",
             }
         }
-        return bus_consume.agents[TENANT][5]
+        return handler._agents[TENANT][5]
 
     def test_member_added_backfills_logged_at_after_bootstrap(self, handler, frozen_now):
-        self._bootstrapped_agent(["support"])
+        self._bootstrapped_agent(handler, ["support"])
 
         handler._queue_member_added(_member_added_event("support"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == ["support"]
         assert agent["logged_at"] == frozen_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     def test_member_pause_backfills_paused_at_after_bootstrap(self, handler, frozen_now):
-        self._bootstrapped_agent(["support"], paused_queues=["support"])
+        self._bootstrapped_agent(handler, ["support"], paused_queues=["support"])
 
         handler._queue_member_pause(_member_pause_event("support", paused="1"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["paused_queues"] == ["support"]
         assert agent["paused_at"] == frozen_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
@@ -800,7 +811,7 @@ class TestLegacyQueueFieldBackCompat:
         assert result[1]["is_logged"] is False
 
     def test_queue_not_reset_to_false_on_full_logout(self, handler):
-        bus_consume.agents[TENANT] = {
+        handler._agents[TENANT] = {
             5: bus_consume._build_agent_state(
                 5, "1001", "John Doe", ["support"], [], home_queue="support"
             )
@@ -808,7 +819,7 @@ class TestLegacyQueueFieldBackCompat:
 
         handler._queue_member_removed(_member_removed_event("support"))
 
-        agent = bus_consume.agents[TENANT][5]
+        agent = handler._agents[TENANT][5]
         assert agent["queues"] == []
         assert agent["is_logged"] is False
         assert agent["queue"] == "support"  # NOT False
@@ -855,8 +866,8 @@ class TestBuildAgentState:
 class TestMalformedMemberEvents:
     """A membership event missing a required field is dropped, not crashed on."""
 
-    def _seed_agent(self, queues):
-        bus_consume.agents[TENANT] = {
+    def _seed_agent(self, handler, queues):
+        handler._agents[TENANT] = {
             5: {
                 "id": 5,
                 "number": "1001",
@@ -871,7 +882,7 @@ class TestMalformedMemberEvents:
 
     @pytest.mark.parametrize("event_type", ["QueueMemberAdded", "QueueMemberRemoved"])
     def test_member_event_without_queue_is_dropped(self, handler, event_type):
-        self._seed_agent(["support"])
+        self._seed_agent(handler, ["support"])
         event = {
             "Event": event_type,
             "Membership": "dynamic",
@@ -884,11 +895,11 @@ class TestMalformedMemberEvents:
         # Must not raise (no KeyError) and must leave existing state untouched.
         handler._agents_status(event, TENANT)
 
-        assert bus_consume.agents[TENANT][5]["queues"] == ["support"]
+        assert handler._agents[TENANT][5]["queues"] == ["support"]
         handler.bus_publisher.publish.assert_not_called()
 
     def test_pause_event_without_paused_is_dropped(self, handler):
-        self._seed_agent(["support"])
+        self._seed_agent(handler, ["support"])
         event = {
             "Event": "QueueMemberPause",
             "Membership": "dynamic",
@@ -900,5 +911,175 @@ class TestMalformedMemberEvents:
 
         handler._agents_status(event, TENANT)
 
-        assert bus_consume.agents[TENANT][5]["paused_queues"] == []
+        assert handler._agents[TENANT][5]["paused_queues"] == []
         handler.bus_publisher.publish.assert_not_called()
+
+
+class TestThreadSafety:
+    """The bus consumer thread and the REST worker threads share the same
+    in-memory state, so concurrent access must be serialised by ``_lock``.
+
+    Without the lock, the ``QueueCallerLeave`` loop iterating the tenant's agent
+    dict while another thread inserts a new agent raises
+    ``RuntimeError: dictionary changed size during iteration`` (and can corrupt
+    the counters). This test hammers both paths concurrently and asserts neither
+    thread raises.
+    """
+
+    def _caller_leave_event(self):
+        # ConnectedLineNum is a real agent number so the full dict is iterated
+        # (no early break), maximising the window for a concurrent insert.
+        return {
+            "Event": "QueueCallerLeave",
+            "ConnectedLineNum": "9999",  # never matches -> iterate everything
+            "CallerIDNum": "2000",
+            "CallerIDName": "Bob",
+        }
+
+    def _member_added_event(self, agent_id):
+        return {
+            "Event": "QueueMemberAdded",
+            "Membership": "dynamic",
+            "Interface": f"Local/id-{agent_id}@agentcallback",
+            "MemberName": f"Agent/{1000 + agent_id}",
+            "Queue": "support",
+            "StateInterface": f"Local/id-{agent_id}@agentcallback",
+        }
+
+    def test_concurrent_read_and_insert_do_not_corrupt_state(self, handler):
+        handler.confd.agents.get.return_value = {
+            "firstname": "New",
+            "lastname": "Agent",
+            "queues": [],
+        }
+        # Seed the tenant so the reader has a dict to iterate from the start.
+        handler._agents[TENANT] = {
+            5: _build_seed_agent(5, "1001", ["support"]),
+        }
+
+        iterations = 300
+        errors = []
+        start = threading.Barrier(2)
+
+        def reader():
+            start.wait()
+            try:
+                for _ in range(iterations):
+                    handler._agents_status(self._caller_leave_event(), TENANT)
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(("reader", exc))
+
+        def writer():
+            start.wait()
+            try:
+                for i in range(iterations):
+                    handler._agents_status(
+                        self._member_added_event(100 + i), TENANT
+                    )
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(("writer", exc))
+
+        threads = [threading.Thread(target=reader), threading.Thread(target=writer)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # Every agent the writer logged in is present and fully formed.
+        assert len(handler._agents[TENANT]) == iterations + 1
+        for state in handler._agents[TENANT].values():
+            assert state["queues"] == ["support"] or state["id"] == 5
+
+    def test_concurrent_livestats_counters_are_consistent(self, handler):
+        # Two threads driving join/leave on the same queue must not lose updates
+        # or trip over the shared ``waiting_calls`` list.
+        iterations = 300
+        errors = []
+        start = threading.Barrier(2)
+
+        def joiner():
+            start.wait()
+            try:
+                for i in range(iterations):
+                    handler._livestats(_join_event(f"j-{i}", count="1"), TENANT)
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(("joiner", exc))
+
+        def leaver():
+            start.wait()
+            try:
+                for i in range(iterations):
+                    handler._livestats(_leave_event(f"j-{i}"), TENANT)
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(("leaver", exc))
+
+        threads = [threading.Thread(target=joiner), threading.Thread(target=leaver)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        stats = handler._stats["support"]
+        # Every leave increments received; counters stay coherent (no lost +=).
+        assert stats["received"] == iterations
+        assert stats["answered"] == iterations
+
+    def test_state_methods_are_mutually_exclusive(self, handler):
+        """Deterministic proof that ``_lock`` serialises state access.
+
+        While a REST worker holds the lock inside ``get_agents_status`` (modelled
+        by a blocking ``confd.agents.list`` — the real call releases the GIL on
+        network I/O), the bus consumer thread must not be able to run
+        ``_livestats`` concurrently. Without the lock this assertion fails
+        because the second thread runs immediately.
+        """
+        entered = threading.Event()
+        other_done = threading.Event()
+
+        def slow_list(**kwargs):
+            # We are inside get_agents_status, holding the lock. Let the other
+            # thread attempt its (lock-guarded) call and assert it cannot finish
+            # while we still hold the lock.
+            entered.set()
+            assert not other_done.wait(timeout=0.2), (
+                "a second thread mutated state while get_agents_status held the lock"
+            )
+            return {"items": []}
+
+        handler.confd.agents.list.side_effect = slow_list
+        handler.agentd.agents.get_agent_statuses.return_value = []
+
+        def contender():
+            entered.wait(timeout=1.0)
+            handler._livestats(_join_event("c-1", count="1"), TENANT)
+            other_done.set()
+
+        thread = threading.Thread(target=contender)
+        thread.start()
+        handler.get_agents_status(TENANT)
+        thread.join(timeout=1.0)
+
+        assert other_done.is_set()  # contender eventually ran once lock released
+
+
+def _build_seed_agent(agent_id, number, queues):
+    return {
+        "id": agent_id,
+        "number": number,
+        "fullname": "Seed Agent",
+        "queue": queues[0] if queues else False,
+        "queues": list(queues),
+        "paused_queues": [],
+        "is_logged": bool(queues),
+        "is_paused": False,
+        "is_offline": False,
+        "is_talking": False,
+        "is_ringing": False,
+        "logged_at": "",
+        "paused_at": "",
+        "talked_at": "",
+        "talked_with_number": "",
+        "talked_with_name": "",
+    }

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import math
 import re
+import threading
 
 from .events import (
     QueueCallerAbandonEvent,
@@ -19,10 +20,6 @@ from .events import (
     QueueLiveStatsEvent,
     QueueAgentsStatusEvent,
 )
-
-
-stats = {}
-agents = {}
 
 
 logger = logging.getLogger(__name__)
@@ -155,6 +152,17 @@ class QueuesBusEventHandler(object):
         self.bus_publisher = bus_publisher
         self.confd = confd
         self.agentd = agentd
+        # Real-time state, owned by this handler instance (not module globals).
+        # wazo-calld runs as a single process with a cheroot thread pool: the
+        # bus consumer thread mutates this state while REST worker threads read
+        # (and lazily seed) it, so every access is guarded by ``_lock``. The
+        # lock is reentrant because the state methods call one another
+        # (``_agents_status`` -> ``get_agents_status`` -> ``add_agent``).
+        # State is intentionally in-memory: it is rebuilt from agentd/confd on
+        # demand and is not persisted across restarts (see AGENTS.md).
+        self._stats = {}
+        self._agents = {}
+        self._lock = threading.RLock()
 
     def subscribe(self, bus_consumer):
         bus_consumer.subscribe("QueueCallerAbandon", self._queue_caller_abandon)
@@ -274,85 +282,110 @@ class QueuesBusEventHandler(object):
             bus_event = QueueMemberStatusEvent(event, tenant_uuid)
         self.bus_publisher.publish(bus_event)
 
-    def _queue_livestats(self, event, tenant_uuid):
-        bus_event = QueueLiveStatsEvent(event, tenant_uuid)
+    def _queue_livestats(self, tenant_uuid):
+        # Caller holds ``self._lock``. Publishes the whole stats map.
+        bus_event = QueueLiveStatsEvent(self._stats, tenant_uuid)
         self.bus_publisher.publish(bus_event)
 
-    def _queue_agents_status(self, event, tenant_uuid, agent):
-        bus_event = QueueAgentsStatusEvent(event[tenant_uuid][agent], tenant_uuid)
+    def _queue_agents_status(self, tenant_uuid, agent):
+        # Caller holds ``self._lock``. Publishes a single agent object.
+        bus_event = QueueAgentsStatusEvent(self._agents[tenant_uuid][agent], tenant_uuid)
         self.bus_publisher.publish(bus_event)
 
     def get_agents_status(self, tenant_uuid: str) -> dict:
-        if not agents.get(tenant_uuid):
-            agents.update({tenant_uuid: {}})
-            agentList = self.confd.agents.list(tenant_uuid=tenant_uuid)
-            agentStatus = self.agentd.agents.get_agent_statuses(tenant_uuid=tenant_uuid)
-
-            for agent in agentList["items"]:
-                status = next(
-                    (s for s in agentStatus if getattr(s, "id", None) == agent["id"]),
-                    None,
+        with self._lock:
+            if not self._agents.get(tenant_uuid):
+                self._agents.update({tenant_uuid: {}})
+                agentList = self.confd.agents.list(tenant_uuid=tenant_uuid)
+                agentStatus = self.agentd.agents.get_agent_statuses(
+                    tenant_uuid=tenant_uuid
                 )
-                runtime_queues, paused_queues, all_queues = _membership_from_status(
-                    status
-                )
-                # Seed the legacy ``queue`` from agentd's queue list, falling
-                # back to confd when agentd has no status (or no queues) for the
-                # agent, so a configured agent never gets ``queue: false``.
-                home_queues = all_queues or _queue_names(agent)
-                home_queue = home_queues[0] if home_queues else False
 
-                if not agents[tenant_uuid].get(agent["id"]):
-                    agents[tenant_uuid][agent["id"]] = _build_agent_state(
-                        agent["id"],
-                        agent["number"],
-                        _agent_fullname(agent),
-                        runtime_queues,
-                        paused_queues,
-                        home_queue,
+                for agent in agentList["items"]:
+                    status = next(
+                        (
+                            s
+                            for s in agentStatus
+                            if getattr(s, "id", None) == agent["id"]
+                        ),
+                        None,
                     )
-        logger.debug("agents status for tenant %s: %s", tenant_uuid, agents[tenant_uuid])
-        return agents[tenant_uuid]
+                    runtime_queues, paused_queues, all_queues = (
+                        _membership_from_status(status)
+                    )
+                    # Seed the legacy ``queue`` from agentd's queue list, falling
+                    # back to confd when agentd has no status (or no queues) for
+                    # the agent, so a configured agent never gets ``queue:
+                    # false``.
+                    home_queues = all_queues or _queue_names(agent)
+                    home_queue = home_queues[0] if home_queues else False
+
+                    if not self._agents[tenant_uuid].get(agent["id"]):
+                        self._agents[tenant_uuid][agent["id"]] = _build_agent_state(
+                            agent["id"],
+                            agent["number"],
+                            _agent_fullname(agent),
+                            runtime_queues,
+                            paused_queues,
+                            home_queue,
+                        )
+            logger.debug(
+                "agents status for tenant %s: %s",
+                tenant_uuid,
+                self._agents[tenant_uuid],
+            )
+            return self._agents[tenant_uuid]
 
     def add_agent(self, tenant_uuid, agent, member):
-        if not agents[tenant_uuid].get(agent):
-            agentInfo = self.confd.agents.get(
-                resource_or_id=agent, tenant_uuid=tenant_uuid
-            )
-            # Not yet runtime-logged: the triggering membership event populates
-            # ``queues`` right after this call, so seed with empty membership.
-            # ``home_queue`` seeds the legacy ``queue`` string from the
-            # confd-configured queues (matches the pre-multi-queue behaviour).
-            configured = _queue_names(agentInfo)
-            agents[tenant_uuid][agent] = _build_agent_state(
-                agent,
-                member,
-                _agent_fullname(agentInfo),
-                home_queue=configured[0] if configured else False,
-            )
+        with self._lock:
+            if not self._agents[tenant_uuid].get(agent):
+                agentInfo = self.confd.agents.get(
+                    resource_or_id=agent, tenant_uuid=tenant_uuid
+                )
+                # Not yet runtime-logged: the triggering membership event
+                # populates ``queues`` right after this call, so seed with empty
+                # membership. ``home_queue`` seeds the legacy ``queue`` string
+                # from the confd-configured queues (matches the pre-multi-queue
+                # behaviour).
+                configured = _queue_names(agentInfo)
+                self._agents[tenant_uuid][agent] = _build_agent_state(
+                    agent,
+                    member,
+                    _agent_fullname(agentInfo),
+                    home_queue=configured[0] if configured else False,
+                )
 
     def get_stats(self, name):
-        # If the queue stats doesnot exist, create the object with default values || Reset if day is different
-        if not stats.get(name) or (
-            stats.get(name) and stats[name]["updated_at"] != datetime.datetime.now().day
-        ):
-            stats.update(
-                {
-                    name: {
-                        "count": 0,
-                        "count_color": "green",
-                        "received": 0,
-                        "abandonned": 0,
-                        "answered": 0,
-                        "awr": 0,
-                        "waiting_calls": [],
-                        "updated_at": datetime.datetime.now().day,
+        with self._lock:
+            # If the queue stats doesnot exist, create the object with default values || Reset if day is different
+            if not self._stats.get(name) or (
+                self._stats.get(name)
+                and self._stats[name]["updated_at"] != datetime.datetime.now().day
+            ):
+                self._stats.update(
+                    {
+                        name: {
+                            "count": 0,
+                            "count_color": "green",
+                            "received": 0,
+                            "abandonned": 0,
+                            "answered": 0,
+                            "awr": 0,
+                            "waiting_calls": [],
+                            "updated_at": datetime.datetime.now().day,
+                        }
                     }
-                }
-            )
-        return stats[name]
+                )
+            return self._stats[name]
 
     def _agents_status(self, event, tenant_uuid):
+        with self._lock:
+            self._agents_status_locked(event, tenant_uuid)
+
+    def _agents_status_locked(self, event, tenant_uuid):
+        # Caller holds ``self._lock``. ``agents`` aliases the instance state so
+        # the body below reads/mutates the shared dict under the lock.
+        agents = self._agents
         agent = 0
 
         required = _REQUIRED_EVENT_FIELDS.get(event.get("Event"))
@@ -514,9 +547,15 @@ class QueuesBusEventHandler(object):
             _sync_derived(state)
 
         if agent != 0:
-            self._queue_agents_status(agents, tenant_uuid, agent)
+            self._queue_agents_status(tenant_uuid, agent)
 
     def _livestats(self, event, tenant_uuid):
+        with self._lock:
+            self._livestats_locked(event, tenant_uuid)
+
+    def _livestats_locked(self, event, tenant_uuid):
+        # Caller holds ``self._lock``. ``stats`` aliases the instance state.
+        stats = self._stats
         name = event["Queue"]
 
         self.get_stats(name)
@@ -570,7 +609,7 @@ class QueuesBusEventHandler(object):
         if stats[name]["count"] > 1:
             stats[name]["count_color"] = "red"
 
-        self._queue_livestats(stats, tenant_uuid)
+        self._queue_livestats(tenant_uuid)
 
     def _extract_tenant_uuid(self, event):
         try:


### PR DESCRIPTION
Closes #11 (stacked on #10 — base is `feat/bootstrap-per-queue-seed`; retarget to `master` once #10 merges).

## Context

Issue #11 framed the problem as multi-worker divergence + restart loss and floated Redis or a single-consumer cache. Investigating the actual deployment model invalidates that framing:

- `wazo-calld` runs as a **single process** with a cheroot thread pool (`max_threads`, default 10); the bus consumer runs in that same process (`wazo_calld/http_server.py`, `controller.py` upstream).
- So the module-level `stats` / `agents` dicts were **already shared** across the bus thread and REST worker threads — there is no cross-worker divergence to reconcile, and Redis isn't in a default Wazo stack anyway.
- The real, latent bug is **thread-safety**: REST handlers lazily seed state (writes, with confd/agentd I/O that releases the GIL), so a REST init can race the bus thread iterating/mutating the same dict (`RuntimeError: dictionary changed size during iteration`, lost counter updates).

## Change

- Move real-time state onto the `QueuesBusEventHandler` instance (`self._stats`, `self._agents`) instead of module globals.
- Guard every access with a reentrant `self._lock` (reentrant because the state methods call one another). The two large handlers delegate to a `*_locked` helper to avoid re-indenting their bodies.
- Agents stay rebuilt lazily from agentd/confd; **stats remain intentionally ephemeral** (live counters, self-reset on day change). Durable queue history belongs to `wazo_call_logd_queue` / `queue_log`.

## Acceptance criteria (#11)

- ✅ Same result regardless of worker — single process, true by construction (documented).
- ✅ Survives restart for `agents` (lazy rebuild from agentd/confd); `stats` ephemeral, explicitly decided and documented.
- ✅ Multi-tenant preserved (`tenant_uuid` keying unchanged).
- ✅ Architecture choice documented; `AGENTS.md` updated.

## Tests

- Drop the now-useless module-state reset fixture; key seed helpers off the handler instance.
- New `TestThreadSafety` with a **deterministic mutual-exclusion test** — verified red without the lock, green with it — plus two concurrency smoke tests.
- `pytest tests/` → **68 passed**.

## Tradeoffs

- The lock is held during `bus_publisher.publish` and during the confd/agentd I/O of lazy init. Acceptable: the bus consumer is already single-threaded (publishes serialized) and init is rare; this is the safest correct behavior (prevents duplicate concurrent init).

## Docs

- `AGENTS.md`: "Behavior to preserve" rewritten (instance-owned, lock-guarded, single-process, ephemeral stats).
- `docs/FRONTEND_INTEGRATION.md`: §1 and §9 corrected (no per-worker divergence; snapshot+subscribe still valid for restart).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for all queue live stats and agent status; incorrect locking could deadlock or stall REST/bus threads, though behavior is intended to stay the same aside from thread safety.
> 
> **Overview**
> **Moves real-time queue `stats` / `agents` off module globals onto `QueuesBusEventHandler`** (`self._stats`, `self._agents`) and serializes all reads/writes with a reentrant `threading.RLock`, reflecting that `wazo-calld` is single-process but the bus thread and REST workers share the same dicts.
> 
> State entry points (`get_agents_status`, `get_stats`, `add_agent`, `_agents_status`, `_livestats`) acquire the lock; `_agents_status_locked` / `_livestats_locked` hold the existing logic without re-indenting. **`_queue_livestats` / `_queue_agents_status` now publish from instance state** (whole stats map vs single agent) instead of passing redundant event payloads.
> 
> **Tests** drop the autouse module-state reset, assert via `handler._stats` / `handler._agents`, and add **`TestThreadSafety`** (concurrent agent insert vs leave iteration, join/leave counters, deterministic lock mutual-exclusion during slow `get_agents_status`).
> 
> **Docs** (`AGENTS.md`, `docs/FRONTEND_INTEGRATION.md`) replace “per-worker” divergence with single-process shared state, lock requirement, and ephemeral stats after restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d169060099c67f350e94ab05cf676ab2aff49834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->