### PR TITLE
feat: expose configured_queues for logged-off multi-queue agents (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,14 @@ Version source: `wazo/plugin.yml`.
   runtime membership in `queues` and per-queue pause in `paused_queues`;
   `queue`, `is_logged`, and `is_paused` are derived from these via
   `_sync_derived` and never written directly.
+- `configured_queues` is the agent's full confd-configured queue roster,
+  **independent of login state** (issue #13). It is seeded at bootstrap
+  (`get_agents_status` / `add_agent`, from agentd's queue list or confd) and
+  kept a superset of `queues` on `QueueMemberAdded`, so a logged-off configured
+  member stays discoverable per queue. It does **not** feed `is_logged` /
+  `is_paused` — those stay derived from runtime `queues` / `paused_queues`.
+  Clients build a queue's roster from `configured_queues` and render per-queue
+  status from `queues` / `paused_queues` (see `docs/FRONTEND_INTEGRATION.md`).
 - Republish enriched events to the front-end websocket.
 - In-memory state is **not persisted across restarts**: `agents` is rebuilt
   lazily from agentd/confd on demand (session timestamps stay empty until the

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -129,7 +129,8 @@ An agent can serve **several queues at once**. Each agent object exposes:
 | `id` | int | agent id (merge key) | — |
 | `number` | string | agent number | — |
 | `fullname` | string | display name | — |
-| `queues` | string[] | queues the agent is **currently** a member of (runtime) | per-queue |
+| `queues` | string[] | queues the agent is **currently** a member of (runtime, logged in) | per-queue |
+| `configured_queues` | string[] | **every** queue the agent is configured for in confd, **independent of login** | per-queue |
 | `paused_queues` | string[] | queues in which the agent is **currently paused** | per-queue |
 | `queue` | string \| false | legacy single-queue field — first runtime queue while logged in, else last-known/home queue; **not reset on logout** (back-compat) | derived |
 | `is_logged` | bool | `queues` is non-empty | derived |
@@ -144,6 +145,22 @@ An agent can serve **several queues at once**. Each agent object exposes:
 
 Rules to implement correctly:
 
+- **Build a queue's roster from `configured_queues`, render status from
+  `queues` / `paused_queues`.** `queues` lists only the queues the agent is
+  *currently logged into*, so a configured member who is logged off has
+  `queues: []` and would be **invisible** if you built the roster from `queues`
+  alone. List a queue's members as every agent with that queue in
+  `configured_queues`, then derive each agent's **per-queue** status:
+  - present/connected → the queue is also in `queues`
+  - paused → the queue is in `paused_queues`
+  - disconnected → the queue is only in `configured_queues`
+
+  This is the multi-queue fix for issue #13: an agent logged into queue A but
+  configured for A+B shows as connected under A and disconnected under B. Do
+  **not** use the agent-global `is_logged` / `is_paused` to render per-queue
+  status — they are OR-ed across all queues and cannot express "connected to A,
+  disconnected from B". (Device fields `is_talking` / `is_ringing` /
+  `is_offline` *are* global — see below.)
 - **Use `queues`, not `queue`.** `queue` is only the first element, provided so
   older clients keep working. A multi-queue UI must read `queues`.
 - **`is_logged` / `is_paused` are derived — never authoritative on their own.**
@@ -199,6 +216,7 @@ the agent object; the client just consumes `queue_agents_status`.
     "fullname": "John Doe",
     "queue": "support",
     "queues": ["support", "sales"],
+    "configured_queues": ["support", "sales"],
     "paused_queues": ["sales"],
     "is_logged": true,
     "is_paused": true,
@@ -228,6 +246,7 @@ The websocket envelope wraps the payload in `data` (Wazo convention). The
     "fullname": "John Doe",
     "queue": "sales",
     "queues": ["sales"],
+    "configured_queues": ["support", "sales"],
     "paused_queues": [],
     "is_logged": true,
     "is_paused": false,
@@ -299,15 +318,22 @@ websocket.on('queue_livestats', ({ data: map }) => {
   Object.assign(stats, map);                          // merge by queue name
 });
 
-// Rendering an agent's queues (multi-queue aware)
-function renderAgent(a) {
-  const queues = a.queues;                            // NOT a.queue
-  const paused = new Set(a.paused_queues);
-  return queues.map(q => ({
-    queue: q,
-    paused: paused.has(q),                            // per-queue pause
-  }));
-  // a.is_talking / a.is_ringing / a.is_offline are global to the agent
+// A queue's roster (incl. logged-off members) + per-queue status
+function rosterFor(agents, queue) {
+  const logged = a => new Set(a.queues).has(queue);
+  const paused = a => new Set(a.paused_queues).has(queue);
+  return Object.values(agents)
+    .filter(a => new Set(a.configured_queues).has(queue))   // roster = configured
+    .map(a => ({
+      id: a.id,
+      // per-queue status — NOT a.is_logged / a.is_paused (those are global)
+      status: a.is_talking ? 'talking'                      // device flags: global
+            : a.is_offline ? 'offline'
+            : a.is_ringing ? 'ringing'
+            : paused(a)    ? 'paused'                        // per-queue
+            : logged(a)    ? 'connected'                     // per-queue
+            :                'disconnected',                 // configured only
+    }));
 }
 ```
 
@@ -318,11 +344,18 @@ function renderAgent(a) {
 - **Initial state reflects live per-queue status.** On first build the server
   reads each agent's current per-queue `logged` / `paused` flags from
   `wazo-agentd`, so `queues` and `paused_queues` are the queues the agent is
-  actually logged into / paused in — not every configured queue. The only
-  fields it cannot recover at bootstrap are the session timestamps
-  (`logged_at` / `paused_at`), which stay empty until the next live event for
-  that agent (agentd exposes no login/pause time). Treat an empty timestamp as
-  "unknown", not "just now".
+  actually logged into / paused in — not every configured queue. The full
+  configured roster is in `configured_queues` instead (from agentd's queue
+  list, or confd when agentd has no status for the agent), so a logged-off
+  member is still discoverable per queue. The only fields it cannot recover at
+  bootstrap are the session timestamps (`logged_at` / `paused_at`), which stay
+  empty until the next live event for that agent (agentd exposes no login/pause
+  time). Treat an empty timestamp as "unknown", not "just now".
+- **`configured_queues` is a confd snapshot.** It is seeded at bootstrap (and
+  when an agent is first seen on a live event) and kept a superset of `queues`
+  as the agent logs in. Like the rest of this in-memory model, a confd
+  membership change made mid-session is not reflected until the next
+  `wazo-calld` restart re-bootstraps the state.
 - **`talked_with_*` is populated on `QueueCallerLeave`** (when a caller is
   connected to the agent) and cleared when the call ends.
 - **`queue` is a back-compat string, not a logout signal.** It stays a

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -627,12 +627,17 @@ class TestMultiQueueMembership:
     def test_member_added_seeds_configured_queues_when_absent(self, handler):
         # Defensive: a state created before ``configured_queues`` existed (e.g.
         # a rolling deploy or an older bootstrap) must not KeyError on a live
-        # join — the field is seeded lazily.
+        # join — the field is seeded lazily. It must seed from the EXISTING
+        # runtime ``queues`` (not empty), so the ``queues ⊆ configured_queues``
+        # invariant holds: a queue the agent is already logged into must not
+        # vanish from the roster just because the new queue triggered seeding.
         self._logged_agent(handler, ["support"])  # no configured_queues key
 
         handler._queue_member_added(_member_added_event("sales"))
 
-        assert "sales" in handler._agents[TENANT][5]["configured_queues"]
+        configured = handler._agents[TENANT][5]["configured_queues"]
+        assert "support" in configured  # pre-existing runtime queue preserved
+        assert "sales" in configured
 
     def test_member_removed_from_one_queue_stays_logged(self, handler):
         self._logged_agent(handler, ["support", "sales"])

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -360,6 +360,51 @@ class TestGetAgentsStatus:
 
         handler.confd.agents.list.assert_called_once()
 
+    def test_configured_queues_exposes_logged_off_membership(self, handler):
+        # A multi-queue agent configured in support+test but logged off (no
+        # agentd status): runtime ``queues`` stays empty, but the full confd
+        # roster must surface in ``configured_queues`` so a client can list the
+        # agent as a (disconnected) member of BOTH queues. This is the issue #13
+        # gap: the legacy ``queue`` carries only the first queue, hiding ``test``.
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {
+                    "id": 3,
+                    "firstname": "Mathias",
+                    "lastname": "Wolff",
+                    "number": "8002",
+                    "queues": [{"name": "support"}, {"name": "test"}],
+                }
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = []
+
+        result = handler.get_agents_status(TENANT)
+
+        assert result[3]["configured_queues"] == ["support", "test"]
+        assert result[3]["queues"] == []
+        assert result[3]["is_logged"] is False
+
+    def test_configured_queues_is_superset_of_runtime_membership(self, handler):
+        # Agent 3 logged into support only, but configured for support+test:
+        # ``queues`` reflects runtime (support), ``configured_queues`` the full
+        # roster (support+test) so ``test`` shows the agent as a disconnected
+        # member there.
+        handler.confd.agents.list.return_value = {
+            "items": [
+                {"id": 3, "firstname": "Mathias", "lastname": "Wolff", "number": "8002"}
+            ]
+        }
+        handler.agentd.agents.get_agent_statuses.return_value = [
+            _agentd_status(3, [("support", True, False), ("test", False, False)]),
+        ]
+
+        result = handler.get_agents_status(TENANT)
+
+        assert result[3]["queues"] == ["support"]
+        assert result[3]["configured_queues"] == ["support", "test"]
+        assert result[3]["is_logged"] is True
+
 
 class TestAddAgent:
     def test_adds_missing_agent_from_confd(self, handler):
@@ -564,6 +609,30 @@ class TestMultiQueueMembership:
         agent = handler._agents[TENANT][5]
         assert agent["queues"] == ["support", "sales"]
         assert agent["is_logged"] is True
+
+    def test_member_added_keeps_configured_roster_a_superset(self, handler):
+        # An agent can only log into a queue it is configured for, so a runtime
+        # join must surface in ``configured_queues`` too (issue #13 invariant
+        # ``queues ⊆ configured_queues``): the live event corrects a roster the
+        # bootstrap missed (e.g. queue configured mid-session).
+        agent = self._logged_agent(handler, ["support"])
+        agent["configured_queues"] = ["support"]
+
+        handler._queue_member_added(_member_added_event("sales"))
+
+        agent = handler._agents[TENANT][5]
+        assert agent["queues"] == ["support", "sales"]
+        assert agent["configured_queues"] == ["support", "sales"]
+
+    def test_member_added_seeds_configured_queues_when_absent(self, handler):
+        # Defensive: a state created before ``configured_queues`` existed (e.g.
+        # a rolling deploy or an older bootstrap) must not KeyError on a live
+        # join — the field is seeded lazily.
+        self._logged_agent(handler, ["support"])  # no configured_queues key
+
+        handler._queue_member_added(_member_added_event("sales"))
+
+        assert "sales" in handler._agents[TENANT][5]["configured_queues"]
 
     def test_member_removed_from_one_queue_stays_logged(self, handler):
         self._logged_agent(handler, ["support", "sales"])

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.3.1
+version: 2.4.0
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/api.yml
+++ b/wazo_calld_queue/api.yml
@@ -174,7 +174,22 @@ definitions:
           compatibility; prefer `queues` for multi-queue agents.
         type: string
       queues:
-        description: Names of the queues the agent is currently a member of
+        description: >-
+          Names of the queues the agent is **currently** a member of at
+          runtime (logged in). Empty when the agent is logged off, even if it
+          is a configured member — use `configured_queues` for the full roster.
+        type: array
+        items:
+          type: string
+      configured_queues:
+        description: >-
+          Names of every queue the agent is configured for in confd,
+          **independent of login state**. Unlike `queues`, this stays populated
+          while the agent is logged off, so a client can list the agent as a
+          (disconnected) member of each queue. To render an agent's status in a
+          given queue: present when the queue is also in `queues`, paused when
+          in `paused_queues`, otherwise disconnected. Does not feed `is_logged`
+          / `is_paused`.
         type: array
         items:
           type: string

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -108,7 +108,13 @@ def _membership_from_status(status):
 
 
 def _build_agent_state(
-    agent_id, number, fullname, queues=None, paused_queues=None, home_queue=False
+    agent_id,
+    number,
+    fullname,
+    queues=None,
+    paused_queues=None,
+    home_queue=False,
+    configured_queues=None,
 ):
     """Build a fresh agent state dict.
 
@@ -122,6 +128,13 @@ def _build_agent_state(
     ``home_queue`` seeds the legacy ``queue`` field (kept for v2.0.x clients)
     so a logged-out agent still carries a queue-name string rather than
     ``False``; when logged in, ``queue`` tracks the first runtime queue.
+
+    ``configured_queues`` is the agent's full confd-configured queue roster,
+    **independent of login state**. Unlike ``queues`` (runtime membership), it
+    lists every queue the agent belongs to even while logged off, so a client
+    can render the complete per-queue roster — marking a member present when the
+    queue is also in ``queues``, paused when in ``paused_queues``, else
+    disconnected. It does NOT feed ``is_logged`` / ``is_paused`` (see issue #13).
     """
     runtime_queues = list(queues or [])
     paused_queues = [q for q in (paused_queues or []) if q in runtime_queues]
@@ -131,6 +144,7 @@ def _build_agent_state(
         "fullname": fullname,
         "queue": home_queue or False,
         "queues": runtime_queues,
+        "configured_queues": list(configured_queues or []),
         "paused_queues": paused_queues,
         "is_logged": False,
         "is_paused": False,
@@ -313,10 +327,12 @@ class QueuesBusEventHandler(object):
                     runtime_queues, paused_queues, all_queues = (
                         _membership_from_status(status)
                     )
-                    # Seed the legacy ``queue`` from agentd's queue list, falling
-                    # back to confd when agentd has no status (or no queues) for
-                    # the agent, so a configured agent never gets ``queue:
-                    # false``.
+                    # The full configured roster: agentd reports every queue the
+                    # agent is configured for (with per-queue flags), falling
+                    # back to confd when agentd has no status for the agent. Used
+                    # both to seed the legacy ``queue`` (first element, so a
+                    # configured agent never gets ``queue: false``) and the
+                    # login-independent ``configured_queues`` (issue #13).
                     home_queues = all_queues or _queue_names(agent)
                     home_queue = home_queues[0] if home_queues else False
 
@@ -328,6 +344,7 @@ class QueuesBusEventHandler(object):
                             runtime_queues,
                             paused_queues,
                             home_queue,
+                            configured_queues=home_queues,
                         )
             logger.debug(
                 "agents status for tenant %s: %s",
@@ -353,6 +370,7 @@ class QueuesBusEventHandler(object):
                     member,
                     _agent_fullname(agentInfo),
                     home_queue=configured[0] if configured else False,
+                    configured_queues=configured,
                 )
 
     def get_stats(self, name):
@@ -459,8 +477,14 @@ class QueuesBusEventHandler(object):
             # Handle connection to a queue (an agent may serve several queues)
             state = agents[tenant_uuid][agent]
             state.setdefault("queues", [])
+            state.setdefault("configured_queues", [])
             if event["Queue"] not in state["queues"]:
                 state["queues"].append(event["Queue"])
+            # An agent only logs into a queue it is configured for, so keep the
+            # roster a superset of runtime membership (issue #13): this also
+            # backfills a queue the bootstrap roster missed.
+            if event["Queue"] not in state["configured_queues"]:
+                state["configured_queues"].append(event["Queue"])
             state["interface"] = event["StateInterface"]
             if not state.get("logged_at"):
                 # LoginTime: set on first observed queue join, kept across

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -477,7 +477,11 @@ class QueuesBusEventHandler(object):
             # Handle connection to a queue (an agent may serve several queues)
             state = agents[tenant_uuid][agent]
             state.setdefault("queues", [])
-            state.setdefault("configured_queues", [])
+            # Seed the roster from the EXISTING runtime queues (not empty) when a
+            # state predates the field (rolling deploy), so an already-logged-in
+            # queue is not dropped from the roster — preserves queues ⊆
+            # configured_queues.
+            state.setdefault("configured_queues", list(state["queues"]))
             if event["Queue"] not in state["queues"]:
                 state["queues"].append(event["Queue"])
             # An agent only logs into a queue it is configured for, so keep the


### PR DESCRIPTION
## Summary

Resolves the residual half of #13: a multi-queue agent that is **logged off** is now discoverable per queue.

Captured data on a live stack confirmed the original `queue: false` symptom was already fixed on `master` (`041b3d9`). The real residual bug: the legacy `queue` field is single-valued, so an agent configured in `support`+`test` and logged off returned `queue: "support"`, `queues: []` — **invisible for the `test` queue roster**.

This PR adds **`configured_queues`**: the full confd-configured queue roster, **independent of login state**, kept a superset of runtime `queues`.

## What changed

- **`bus_consume.py`** — new `configured_queues` field in `_build_agent_state`; seeded in `get_agents_status` (`= home_queues`, i.e. agentd's queue list or confd fallback) and `add_agent` (`= confd _queue_names`); backfilled on `QueueMemberAdded` with a defensive `setdefault` (rolling-deploy safe).
- **Invariant preserved** — `is_logged` / `is_paused` stay derived from runtime `queues` / `paused_queues` via `_sync_derived`; `configured_queues` never feeds them.
- **Docs** — `api.yml` (Swagger field), `docs/FRONTEND_INTEGRATION.md` (§5 table, §8 roster pseudo-code, §9 caveats), `AGENTS.md` behavior notes.
- **Version** — `2.3.1` → `2.4.0` (additive, backward-compatible).

## How clients use it

Build a queue's roster from `configured_queues`, then derive **per-queue** status:
- in `queues` → connected · in `paused_queues` → paused · only in `configured_queues` → disconnected
- device flags (`is_talking` / `is_ringing` / `is_offline`) stay global.

## Tests

TDD (RED → GREEN → REFACTOR). Added to `tests/test_bus_consume.py`:
- logged-off multi-queue agent → `configured_queues` populated, `queues: []`, `is_logged: false`
- logged into a subset → `configured_queues` is the superset of `queues`
- `QueueMemberAdded` keeps `configured_queues` a superset (+ backfill)
- defensive: live event on pre-field state does not `KeyError`

`pytest tests/` → **72 passed**.

## Frontend

Frontend half tracked in wazo-communication/wda-supervisor#16.

Refs #13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API field with backward-compatible behavior; login/pause derivation unchanged. Main caveat is in-memory roster can lag confd until restart, as documented.
> 
> **Overview**
> Adds **`configured_queues`** to agent status (REST + `queue_agents_status` events): the full confd/agentd queue roster **regardless of login**, so logged-off multi-queue agents still appear on every configured queue (fixes #13).
> 
> **`bus_consume.py`** extends `_build_agent_state`, seeds `configured_queues` in `get_agents_status` and `add_agent`, and on `QueueMemberAdded` keeps it a superset of runtime `queues` (with rolling-deploy `setdefault`). **`is_logged` / `is_paused`** are unchanged — still from `queues` / `paused_queues` only.
> 
> Docs (`api.yml`, `FRONTEND_INTEGRATION.md`, `AGENTS.md`) describe roster = `configured_queues`, per-queue status from `queues` / `paused_queues`. Plugin version **2.3.1 → 2.4.0**; new unit tests cover bootstrap, superset invariant, and live join backfill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752db6d190cacc28a0b0f4cd78752f409980eecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->