### PR TITLE
fix: sync configured_queues from confd member (dis)association events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,15 @@ Version source: `wazo/plugin.yml`.
   **independent of login state** (issue #13). It is seeded at bootstrap
   (`get_agents_status` / `add_agent`, from agentd's queue list or confd) and
   kept a superset of `queues` on `QueueMemberAdded`, so a logged-off configured
-  member stays discoverable per queue. It does **not** feed `is_logged` /
+  member stays discoverable per queue. It is **resynced from confd** on the
+  confd config events `queue_member_agent_associated` /
+  `queue_member_agent_dissociated` (`_sync_configured_queues`): those events only
+  carry `queue_id` / `agent_id`, so the handler re-fetches the agent from confd
+  to resolve the tenant and the authoritative queue-name roster, then reconciles
+  the cached state (pruning runtime `queues` / `paused_queues` to keep
+  `paused_queues ⊆ queues ⊆ configured_queues`). Without this, a queue removed
+  from a logged-off agent in confd would stay in `configured_queues` until the
+  next process restart. It does **not** feed `is_logged` /
   `is_paused` — those stay derived from runtime `queues` / `paused_queues`.
   Clients build a queue's roster from `configured_queues` and render per-queue
   status from `queues` / `paused_queues` (see `docs/FRONTEND_INTEGRATION.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confd. Previously a queue removed from a **logged-off** agent in confd stayed
   in `configured_queues` (and the legacy `queue` field) until the next
   `wazo-calld` restart, because the plugin only learned membership from runtime
-  AMI events and never pruned the configured roster.
+  AMI events and never pruned the configured roster. When the prune empties the
+  agent's runtime membership, session/device fields (`logged_at`, `paused_at`,
+  `is_talking`, …) are cleared just like a regular last-queue logout.
 - The legacy `queue` field is now reset to `false` when an agent is no longer
   configured for any queue. It stays "sticky" (keeps its last-known name) only
   while the agent still belongs to at least one queue — there is no longer a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-06-23
+
+### Fixed
+- `configured_queues` (and runtime `queues` / `paused_queues`) are now kept in
+  sync with confd when an agent is added to or removed from a queue: the handler
+  subscribes to the confd `queue_member_agent_associated` /
+  `queue_member_agent_dissociated` events and resyncs the cached roster from
+  confd. Previously a queue removed from a **logged-off** agent in confd stayed
+  in `configured_queues` (and the legacy `queue` field) until the next
+  `wazo-calld` restart, because the plugin only learned membership from runtime
+  AMI events and never pruned the configured roster.
+- The legacy `queue` field is now reset to `false` when an agent is no longer
+  configured for any queue. It stays "sticky" (keeps its last-known name) only
+  while the agent still belongs to at least one queue — there is no longer a
+  home queue to fall back on once the roster is empty.
+
 ## [2.4.0] - 2026-06-23
 
 ### Added

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -1244,6 +1244,53 @@ class TestQueueMemberAgentConfdEvents:
         assert agent["paused_queues"] == []
         assert agent["is_logged"] is True
 
+    def test_dissociation_to_empty_resets_session_fields(self, handler):
+        # Pruning the last runtime queue is a full logout: session/device fields
+        # must be cleared like QueueMemberRemoved does, else the published status
+        # shows is_logged=false with stale login/call data.
+        state = self._seed(handler, 7, configured=["test"], queues=["test"])
+        state.update(
+            logged_at="2026-06-17T12:00:00.000000",
+            paused_at="2026-06-17T12:05:00.000000",
+            is_talking=True,
+            is_ringing=True,
+            talked_at="2026-06-17T12:06:00.000000",
+            talked_with_number="1000",
+            talked_with_name="Alice",
+        )
+        handler.confd.agents.get.return_value = _confd_agent(7, [])
+
+        handler._queue_member_agent_dissociated({"queue_id": 1, "agent_id": 7})
+
+        agent = handler._agents[TENANT][7]
+        assert agent["queues"] == []
+        assert agent["is_logged"] is False
+        assert agent["logged_at"] == ""
+        assert agent["paused_at"] == ""
+        assert agent["is_talking"] is False
+        assert agent["is_ringing"] is False
+        assert agent["talked_at"] == ""
+        assert agent["talked_with_number"] == ""
+        assert agent["talked_with_name"] == ""
+
+    def test_dissociation_keeping_a_queue_preserves_session_fields(self, handler):
+        # A partial prune (one of several runtime queues) is NOT a logout: the
+        # session fields stay untouched.
+        state = self._seed(
+            handler, 7, configured=["support", "test"], queues=["support", "test"]
+        )
+        state.update(
+            logged_at="2026-06-17T12:00:00.000000", is_talking=True
+        )
+        handler.confd.agents.get.return_value = _confd_agent(7, ["support"])
+
+        handler._queue_member_agent_dissociated({"queue_id": 3, "agent_id": 7})
+
+        agent = handler._agents[TENANT][7]
+        assert agent["queues"] == ["support"]
+        assert agent["logged_at"] == "2026-06-17T12:00:00.000000"
+        assert agent["is_talking"] is True
+
     def test_dissociation_publishes_updated_status(self, handler):
         self._seed(handler, 21, configured=["support"])
         handler.confd.agents.get.return_value = _confd_agent(21, [])

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -471,6 +471,8 @@ class TestSubscribe:
             "QueueMemberRemoved",
             "QueueMemberRinginuse",
             "QueueMemberStatus",
+            "queue_member_agent_associated",
+            "queue_member_agent_dissociated",
         }
 
 
@@ -1157,3 +1159,145 @@ def _build_seed_agent(agent_id, number, queues):
         "talked_with_number": "",
         "talked_with_name": "",
     }
+
+
+def _confd_agent(agent_id, queue_names, tenant=TENANT, number="1001"):
+    """Shape of ``confd.agents.get(agent_id)``: the authoritative roster."""
+    return {
+        "id": agent_id,
+        "number": number,
+        "firstname": "John",
+        "lastname": "Doe",
+        "tenant_uuid": tenant,
+        "queues": [{"name": name} for name in queue_names],
+    }
+
+
+class TestQueueMemberAgentConfdEvents:
+    """confd (dis)association events keep ``configured_queues`` in sync with the
+    confd-configured roster, **independent of login state** (issue #13).
+
+    The plugin otherwise only learns membership from runtime AMI events, so a
+    queue removed from a logged-off agent in confd would never be pruned from
+    ``configured_queues`` until the next process restart.
+    """
+
+    def _seed(self, handler, agent_id, configured, queues=None, paused=None):
+        state = bus_consume._build_agent_state(
+            agent_id,
+            "1001",
+            "John Doe",
+            queues=queues or [],
+            paused_queues=paused or [],
+            home_queue=configured[0] if configured else False,
+            configured_queues=configured,
+        )
+        handler._agents[TENANT] = {agent_id: state}
+        return state
+
+    def test_dissociation_prunes_configured_queues(self, handler):
+        # The reported bug: agent logged off but still configured for the queue;
+        # confd now reports an empty roster after the agent was removed.
+        self._seed(handler, 21, configured=["support-88511897"])
+        handler.confd.agents.get.return_value = _confd_agent(21, [])
+
+        handler._queue_member_agent_dissociated(
+            {"queue_id": 1, "agent_id": 21}
+        )
+
+        agent = handler._agents[TENANT][21]
+        assert agent["configured_queues"] == []
+        # No queue configured at all anymore: the legacy ``queue`` string has no
+        # legitimate home to fall back on, so it is reset to ``False``.
+        assert agent["queue"] is False
+        handler.confd.agents.get.assert_called_once_with(21)
+
+    def test_dissociation_keeps_other_configured_queues(self, handler):
+        self._seed(handler, 3, configured=["support", "test"])
+        handler.confd.agents.get.return_value = _confd_agent(3, ["test"])
+
+        handler._queue_member_agent_dissociated({"queue_id": 1, "agent_id": 3})
+
+        agent = handler._agents[TENANT][3]
+        assert agent["configured_queues"] == ["test"]
+        # Still configured for at least one queue: the legacy ``queue`` field
+        # keeps its sticky last-known value (back-compat with v2.0.x clients).
+        assert agent["queue"] == "support"
+
+    def test_dissociation_prunes_runtime_queues_to_keep_invariant(self, handler):
+        # queues ⊆ configured_queues must hold: a runtime queue no longer
+        # configured is dropped from runtime membership and pause too.
+        self._seed(
+            handler,
+            3,
+            configured=["support", "test"],
+            queues=["support", "test"],
+            paused=["test"],
+        )
+        handler.confd.agents.get.return_value = _confd_agent(3, ["support"])
+
+        handler._queue_member_agent_dissociated({"queue_id": 3, "agent_id": 3})
+
+        agent = handler._agents[TENANT][3]
+        assert agent["configured_queues"] == ["support"]
+        assert agent["queues"] == ["support"]
+        assert agent["paused_queues"] == []
+        assert agent["is_logged"] is True
+
+    def test_dissociation_publishes_updated_status(self, handler):
+        self._seed(handler, 21, configured=["support"])
+        handler.confd.agents.get.return_value = _confd_agent(21, [])
+
+        handler._queue_member_agent_dissociated({"queue_id": 1, "agent_id": 21})
+
+        published = _published_events(handler)
+        assert isinstance(published[-1], QueueAgentsStatusEvent)
+        assert published[-1].content == handler._agents[TENANT][21]
+
+    def test_association_adds_to_configured_queues(self, handler):
+        self._seed(handler, 5, configured=["support"])
+        handler.confd.agents.get.return_value = _confd_agent(5, ["support", "sales"])
+
+        handler._queue_member_agent_associated(
+            {"queue_id": 9, "agent_id": 5, "penalty": 0}
+        )
+
+        assert handler._agents[TENANT][5]["configured_queues"] == [
+            "support",
+            "sales",
+        ]
+
+    def test_event_for_unknown_tenant_is_ignored(self, handler):
+        # No state seeded for the tenant confd resolves: nothing to reconcile.
+        handler.confd.agents.get.return_value = _confd_agent(
+            7, ["support"], tenant="other-tenant"
+        )
+
+        handler._queue_member_agent_dissociated({"queue_id": 1, "agent_id": 7})
+
+        assert _published_events(handler) == []
+
+    def test_event_for_unknown_agent_is_ignored(self, handler):
+        self._seed(handler, 5, configured=["support"])
+        handler.confd.agents.get.return_value = _confd_agent(99, ["support"])
+
+        handler._queue_member_agent_dissociated({"queue_id": 1, "agent_id": 99})
+
+        assert _published_events(handler) == []
+        assert handler._agents[TENANT][5]["configured_queues"] == ["support"]
+
+    def test_malformed_event_without_agent_id_is_dropped(self, handler):
+        handler._queue_member_agent_dissociated({"queue_id": 1})
+
+        handler.confd.agents.get.assert_not_called()
+        assert _published_events(handler) == []
+
+    def test_confd_lookup_failure_is_swallowed(self, handler):
+        self._seed(handler, 5, configured=["support"])
+        handler.confd.agents.get.side_effect = RuntimeError("boom")
+
+        handler._queue_member_agent_dissociated({"queue_id": 1, "agent_id": 5})
+
+        # State left untouched, no crash, nothing published.
+        assert handler._agents[TENANT][5]["configured_queues"] == ["support"]
+        assert _published_events(handler) == []

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.4.0
+version: 2.4.1
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -50,6 +50,11 @@ def _sync_derived(state):
     ``False`` on logout**: the last known (or seeded home) queue name is kept so
     a logged-out agent still carries a string. Use ``is_logged`` / ``queues``,
     not ``queue``, to determine connection state.
+
+    The one place ``queue`` *is* reset is when the agent stops being configured
+    for any queue at all (``configured_queues`` empties out): that reset is done
+    by ``_sync_configured_queues`` before calling this helper, since there is no
+    longer a home queue to keep sticky.
     """
     queues = state.setdefault("queues", [])
     paused_queues = state.setdefault("paused_queues", [])
@@ -188,6 +193,18 @@ class QueuesBusEventHandler(object):
         bus_consumer.subscribe("QueueMemberRemoved", self._queue_member_removed)
         bus_consumer.subscribe("QueueMemberRinginuse", self._queue_member_ringinuse)
         bus_consumer.subscribe("QueueMemberStatus", self._queue_member_status)
+        # confd configuration events (not AMI): keep ``configured_queues`` in
+        # sync with the confd-configured roster regardless of login state, so a
+        # queue added to / removed from an agent in confd is reflected without
+        # waiting for a process restart (issue #13). Their payload only carries
+        # ``queue_id`` / ``agent_id``, so the handler re-fetches the agent from
+        # confd to resolve the tenant and the authoritative queue-name roster.
+        bus_consumer.subscribe(
+            "queue_member_agent_associated", self._queue_member_agent_associated
+        )
+        bus_consumer.subscribe(
+            "queue_member_agent_dissociated", self._queue_member_agent_dissociated
+        )
 
     def _queue_caller_abandon(self, event):
         tenant_uuid = self._extract_tenant_uuid(event)
@@ -295,6 +312,66 @@ class QueuesBusEventHandler(object):
             self._agents_status(event, tenant_uuid)
             bus_event = QueueMemberStatusEvent(event, tenant_uuid)
         self.bus_publisher.publish(bus_event)
+
+    def _queue_member_agent_associated(self, event):
+        self._sync_configured_queues(event)
+
+    def _queue_member_agent_dissociated(self, event):
+        self._sync_configured_queues(event)
+
+    def _sync_configured_queues(self, event):
+        """Resync an agent's ``configured_queues`` from confd after a confd
+        (dis)association event.
+
+        These confd events only carry ``queue_id`` / ``agent_id`` (no tenant,
+        no queue name), so we re-fetch the agent from confd to get both the
+        tenant and the authoritative queue-name roster, then reconcile the
+        cached state. The runtime sets are pruned to keep the invariant
+        ``paused_queues ⊆ queues ⊆ configured_queues``. No-op when the agent is
+        not cached (nothing to reconcile — it will be seeded fresh on its next
+        bootstrap or runtime event).
+        """
+        try:
+            agent_id = int(event["agent_id"])
+        except (KeyError, TypeError, ValueError):
+            logger.warning(
+                "Dropping malformed queue_member_agent event (no agent_id): %s",
+                event,
+            )
+            return
+
+        try:
+            agent_info = self.confd.agents.get(agent_id)
+        except Exception:
+            logger.warning(
+                "Could not resolve agent %s from confd to sync configured_queues",
+                agent_id,
+                exc_info=True,
+            )
+            return
+
+        tenant_uuid = agent_info.get("tenant_uuid")
+        configured = _queue_names(agent_info)
+
+        with self._lock:
+            state = (self._agents.get(tenant_uuid) or {}).get(agent_id)
+            if not state:
+                return
+            state["configured_queues"] = configured
+            # Keep paused_queues ⊆ queues ⊆ configured_queues: drop any runtime
+            # membership/pause for a queue the agent is no longer configured for.
+            state["queues"] = [q for q in state.get("queues", []) if q in configured]
+            state["paused_queues"] = [
+                q for q in state.get("paused_queues", []) if q in state["queues"]
+            ]
+            if not configured:
+                # No queue configured anymore: unlike a logged-off-but-configured
+                # agent, there is no home queue to fall back on, so clear the
+                # sticky legacy ``queue`` string instead of keeping a stale name.
+                # (``_sync_derived`` only keeps it sticky; it never resets it.)
+                state["queue"] = False
+            _sync_derived(state)
+            self._queue_agents_status(tenant_uuid, agent_id)
 
     def _queue_livestats(self, tenant_uuid):
         # Caller holds ``self._lock``. Publishes the whole stats map.

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -67,6 +67,24 @@ def _sync_derived(state):
     state["is_paused"] = bool(paused_queues)
 
 
+def _reset_session_fields(state):
+    """Clear per-session/device fields of a fully-logged-out agent.
+
+    Shared by ``QueueMemberRemoved`` (last runtime queue left) and
+    ``_sync_configured_queues`` (a confd dissociation pruned the last runtime
+    queue), so a published ``is_logged: false`` status never carries stale
+    login/call data. ``is_offline`` is intentionally left untouched (it tracks
+    the websocket/device, not the queue session).
+    """
+    state["is_talking"] = False
+    state["is_ringing"] = False
+    state["logged_at"] = ""
+    state["paused_at"] = ""
+    state["talked_at"] = ""
+    state["talked_with_number"] = ""
+    state["talked_with_name"] = ""
+
+
 def _agent_fullname(info):
     fullname = ""
     if str(info["firstname"]) != "None":
@@ -364,6 +382,10 @@ class QueuesBusEventHandler(object):
             state["paused_queues"] = [
                 q for q in state.get("paused_queues", []) if q in state["queues"]
             ]
+            if not state["queues"]:
+                # The prune emptied runtime membership: this is a full logout,
+                # so clear session/device fields like QueueMemberRemoved does.
+                _reset_session_fields(state)
             if not configured:
                 # No queue configured anymore: unlike a logged-off-but-configured
                 # agent, there is no home queue to fall back on, so clear the
@@ -603,13 +625,7 @@ class QueuesBusEventHandler(object):
                 state["paused_queues"].remove(event["Queue"])
             if not state["queues"]:
                 # Fully logged out: reset session/device fields
-                state["is_talking"] = False
-                state["is_ringing"] = False
-                state["logged_at"] = ""
-                state["paused_at"] = ""
-                state["talked_at"] = ""
-                state["talked_with_number"] = ""
-                state["talked_with_name"] = ""
+                _reset_session_fields(state)
             _sync_derived(state)
 
         if event["Event"] == "QueueMemberPause" and event["Membership"] == "dynamic":


### PR DESCRIPTION
## Problème

Quand un agent est retiré d'une file dans confd alors qu'il est **loggé off**, l'API `GET /queues/agents_status` (et l'event `queue_agents_status`) continuait de renvoyer la file dans `configured_queues` — et le champ legacy `queue` gardait le nom de la file — jusqu'au prochain redémarrage de `wazo-calld`.

Cause : le plugin n'apprenait l'appartenance aux files que via les events AMI runtime (`QueueMember*`). `configured_queues` était amorcé au bootstrap puis ne faisait que **grossir** (`QueueMemberAdded`), jamais rétrécir. Aucun event de configuration confd n'était consommé.

Cas reproduit : agent « Agent1 PIERRE » retiré de sa seule file `support-88511897` → confd renvoie `queues: []`, mais le plugin exposait toujours `configured_queues: ["support-88511897"]` et `queue: "support-88511897"`.

## Correctif

- Abonnement aux events de configuration confd `queue_member_agent_associated` / `queue_member_agent_dissociated`.
- Leur payload ne porte que `queue_id` / `agent_id` (ni tenant, ni nom de file), donc on re-fetch l'agent via `confd.agents.get(agent_id)` pour résoudre le tenant et le **roster autoritaire** (noms de files), puis on resynchronise l'état en cache.
- Réimposition de l'invariant `paused_queues ⊆ queues ⊆ configured_queues` (purge des files runtime devenues non-configurées).
- Appel confd **hors lock**, mutation **sous lock**, puis republication du `queue_agents_status` (rafraîchissement live du websocket).
- No-op si l'agent n'est pas en cache (il sera amorcé au prochain bootstrap / event runtime).

### Champ legacy `queue`

Reset à `false` quand l'agent n'est **plus configuré pour aucune file** (plus de home queue sur laquelle retomber). Il reste « collant » (dernière valeur connue) tant qu'au moins une file configurée subsiste — back-compat v2.0.x préservée.

## Tests

TDD (Red → Green → Refactor). Nouvelle classe `TestQueueMemberAgentConfdEvents` couvrant : purge sur dissociation, conservation des autres files, purge des files runtime, ajout sur association, reset du champ legacy `queue`, tenant/agent inconnu ignorés, event malformé droppé, échec confd avalé.

```
81 passed
```

## Notes

- Aucun changement d'ACL : la consommation des events confd se fait par binding sur le nom de l'event (comme `meeting_deleted` dans wazo-calld), pas via ACL.
- Version : 2.4.0 → **2.4.1** (`wazo/plugin.yml` + CHANGELOG).
- Doc `AGENTS.md` mise à jour (cycle de vie de `configured_queues`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live agent status semantics and websocket payloads for confd-driven membership edits; behavior is well-tested but affects queue roster display for logged-off agents.
> 
> **Overview**
> Fixes stale queue rosters when confd changes agent–queue membership while the agent is **logged off**: `GET /queues/agents_status` and `queue_agents_status` no longer keep removed queues until `wazo-calld` restarts.
> 
> The bus handler now listens for confd **`queue_member_agent_associated`** / **`queue_member_agent_dissociated`**, re-fetches the agent via **`confd.agents.get`**, and reconciles **`configured_queues`** plus runtime **`queues`** / **`paused_queues`** (`paused_queues ⊆ queues ⊆ configured_queues`). Confd is called outside the lock; updates and republication happen under **`_lock`**.
> 
> When pruning drops the last runtime queue, **`_reset_session_fields`** clears login/call fields (shared with **`QueueMemberRemoved`**). The legacy **`queue`** field becomes **`false`** only when the agent has **no** configured queues left; it stays sticky if at least one queue remains. Version **2.4.1**; docs and tests added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829b37908b20c94cae1ef456e5cbebdb9d1e21be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->