### PR TITLE
feat: add per-queue connect/disconnect with supervisor scoping (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-06-24
+
+### Added
+- Per-queue agent **connect** / **disconnect** for supervisors:
+  `PUT /queues/{queue_name}/connect` and `PUT /queues/{queue_name}/disconnect`
+  (body `{"agent_id": <int>}`, `204` on success). The endpoint authorizes the
+  caller server-side — the token's user must be an agent that is itself a member
+  of the target queue (confd) — then delegates to `wazo-agentd`
+  (`agent_login_to_queue` / `agent_logoff_from_queue`). No AMI action, no
+  in-memory state mutation and no new bus event: the change propagates through
+  the existing `QueueMemberAdded` / `QueueMemberRemoved` events and the
+  `queue_agents_status` payload. `ALREADY_IN_QUEUE` / `NOT_IN_QUEUE` from agentd
+  are treated as idempotent success (`204`); a missing agent session yields
+  `400`, an unknown agent/queue `404`, an unauthorized supervisor `403`, and any
+  other agentd error `502`. Fixes #3.
+- Two `agentd.agents.*.queues.*.{login,logoff}.update` ACL on the wazo-calld
+  service token (`etc/wazo-auth-keys/conf.d/call_queue.yml`).
+
 ## [2.4.1] - 2026-06-23
 
 ### Fixed
@@ -159,6 +177,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release: Queue REST API and bus events for Asterisk-based queue management.
 
+[2.5.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.4.1...v2.5.0
+[2.4.1]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.2.0...v2.3.0

--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -57,6 +57,8 @@ All REST endpoints are `wazo-auth` protected; pass a valid token. Required ACLs
 | `PUT /queues/{queue_name}/add_member` | `calld.queues.{queue_name}.add_member.update` |
 | `PUT /queues/{queue_name}/remove_member` | `calld.queues.{queue_name}.remove_member.update` |
 | `PUT /queues/{queue_name}/pause_member` | `calld.queues.{queue_name}.pause_member.update` |
+| `PUT /queues/{queue_name}/connect` | `calld.queues.{queue_name}.connect.update` |
+| `PUT /queues/{queue_name}/disconnect` | `calld.queues.{queue_name}.disconnect.update` |
 | `POST /queues/intercept/{queue_name}` | `calld.queues.{queue_name}.intercept.create` |
 
 Bus/websocket events all require `events.calls.me` and are tenant-scoped: you
@@ -75,10 +77,38 @@ only receive events for your own tenant.
 | `PUT` | `/queues/{queue_name}/add_member` | Log a member into a queue | `204` |
 | `PUT` | `/queues/{queue_name}/remove_member` | Remove a member from a queue | `204` |
 | `PUT` | `/queues/{queue_name}/pause_member` | Pause/unpause a member in a queue | `204` |
+| `PUT` | `/queues/{queue_name}/connect` | **Supervisor** connects an agent to a queue | `204` |
+| `PUT` | `/queues/{queue_name}/disconnect` | **Supervisor** disconnects an agent from a queue | `204` |
 | `POST` | `/queues/intercept/{queue_name}` | Intercept a waiting caller | `201` |
 
 `add_member` / `remove_member` / `pause_member` act on **a single queue**. To
 manage an agent serving several queues, call them once per queue.
+
+### Supervisor connect / disconnect
+
+`PUT /queues/{queue_name}/connect` and `PUT /queues/{queue_name}/disconnect`
+let a **supervisor** toggle another agent's membership in one queue. Body:
+
+```json
+{ "agent_id": 42 }
+```
+
+The server authorizes the call **server-side**: the token's user must be an
+agent that is itself a member of `{queue_name}`. The action is delegated to
+`wazo-agentd` (it logs the targeted agent in/out of that single queue). There is
+**no dedicated bus event** — the result propagates through the usual
+`queue_agents_status` event (the target agent's `queues` gains/loses the queue),
+so a client only needs to keep merging that event as usual.
+
+Error codes:
+
+| Code | Meaning |
+|---|---|
+| `204` | Done. Also returned when the agent is **already** (dis)connected (idempotent). |
+| `400` | The targeted agent has no active session — it must log in before being connected. |
+| `403` | The caller is not a member of `{queue_name}` (not allowed to supervise it). |
+| `404` | No such agent or queue. |
+| `502` | Unexpected error from `wazo-agentd`. |
 
 ---
 

--- a/etc/wazo-auth-keys/conf.d/call_queue.yml
+++ b/etc/wazo-auth-keys/conf.d/call_queue.yml
@@ -9,3 +9,5 @@ wazo-calld:
     - 'amid.action.queuepause.create'
     - 'agentd.agents.read'
     - 'agentd.agents.by-id.*.read'
+    - 'agentd.agents.*.queues.*.login.update'
+    - 'agentd.agents.*.queues.*.logoff.update'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,8 +88,71 @@ def _install_wazo_calld_stub():
     sys.modules["wazo_calld.plugin_helpers.mallow"] = mallow_mod
 
 
+def _install_xivo_stub():
+    """Stub ``xivo.rest_api_helpers.APIException`` used by ``exceptions``.
+
+    The plugin's ``exceptions`` module subclasses the real ``APIException``
+    from ``xivo.rest_api_helpers`` (part of the Wazo stack, not installed for
+    isolated unit tests). A minimal base class with the same constructor is
+    enough to import and exercise the exception subclasses.
+    """
+    if "xivo.rest_api_helpers" in sys.modules:
+        return
+
+    class APIException(Exception):
+        def __init__(
+            self, status_code, message, error_id, details=None, resource=None
+        ):
+            super().__init__(message)
+            self.status_code = status_code
+            self.message = message
+            self.id_ = error_id
+            self.details = details or {}
+            self.resource = resource
+
+    mod = types.ModuleType("xivo.rest_api_helpers")
+    mod.APIException = APIException
+    xivo_mod = sys.modules.get("xivo") or types.ModuleType("xivo")
+    xivo_mod.rest_api_helpers = mod
+    sys.modules["xivo"] = xivo_mod
+    sys.modules["xivo.rest_api_helpers"] = mod
+
+
+def _install_wazo_agentd_client_stub():
+    """Stub ``wazo_agentd_client.error`` used by ``services``.
+
+    Mirrors the real module's ``AgentdClientError`` (stores its argument on the
+    ``error`` attribute) and the error-code string constants the service maps
+    to HTTP status codes.
+    """
+    if "wazo_agentd_client.error" in sys.modules:
+        return
+
+    class AgentdClientError(Exception):
+        def __init__(self, error):
+            super().__init__(error)
+            self.error = error
+
+    mod = types.ModuleType("wazo_agentd_client.error")
+    mod.AgentdClientError = AgentdClientError
+    mod.NO_SUCH_AGENT = "no such agent"
+    mod.NO_SUCH_QUEUE = "no such queue"
+    mod.NOT_LOGGED = "not logged in"
+    mod.ALREADY_IN_QUEUE = "agent already in queue"
+    mod.NOT_IN_QUEUE = "agent not in queue"
+
+    agentd_mod = sys.modules.get("wazo_agentd_client") or types.ModuleType(
+        "wazo_agentd_client"
+    )
+    agentd_mod.error = mod
+    sys.modules["wazo_agentd_client"] = agentd_mod
+    sys.modules["wazo_agentd_client.error"] = mod
+
+
 _install_wazo_bus_stub()
 _install_wazo_calld_stub()
+_install_xivo_stub()
+_install_wazo_agentd_client_stub()
 
 # Imported only after the stub is in place.
 from wazo_calld_queue.bus_consume import QueuesBusEventHandler  # noqa: E402

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,6 +5,21 @@ from unittest.mock import Mock
 
 import pytest
 
+from wazo_agentd_client.error import (
+    AgentdClientError,
+    ALREADY_IN_QUEUE,
+    NOT_IN_QUEUE,
+    NOT_LOGGED,
+    NO_SUCH_AGENT,
+    NO_SUCH_QUEUE,
+)
+
+from wazo_calld_queue.exceptions import (
+    AgentdUpstreamError,
+    AgentNotLogged,
+    NoSuchAgentOrQueue,
+    SupervisorNotInQueue,
+)
 from wazo_calld_queue.services import QueueService
 
 
@@ -164,3 +179,129 @@ class TestStatsDelegation:
 
         service.publisher.get_agents_status.assert_called_once_with("tenant-1")
         assert result is service.publisher.get_agents_status.return_value
+
+
+class TestConnectDisconnectAgent:
+    """Per-queue connect/disconnect: authorize the supervisor against the
+    target queue (confd), then delegate to agentd."""
+
+    def _authorize_supervisor_for(self, service, queue_name="support", queue_id=42):
+        service.confd.users.get.return_value = {"agent": {"id": 7}}
+        service.confd.agents.get.return_value = {
+            "queues": [{"id": queue_id, "name": queue_name}]
+        }
+
+    def test_connect_authorized_delegates_to_agentd(self, service):
+        self._authorize_supervisor_for(service)
+
+        service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.confd.users.get.assert_called_once_with(
+            "sup-uuid", tenant_uuid="t1"
+        )
+        service.confd.agents.get.assert_called_once_with(7, tenant_uuid="t1")
+        service.agentd.agents.agent_login_to_queue.assert_called_once_with(
+            3, 42, tenant_uuid="t1"
+        )
+
+    def test_disconnect_authorized_delegates_to_agentd(self, service):
+        self._authorize_supervisor_for(service)
+
+        service.disconnect_agent("support", 3, "sup-uuid", "t1")
+
+        service.agentd.agents.agent_logoff_from_queue.assert_called_once_with(
+            3, 42, tenant_uuid="t1"
+        )
+
+    def test_authorization_is_scoped_to_request_tenant(self, service):
+        # The supervisor/agent lookups and the agentd action must all carry the
+        # request tenant, so a supervisor cannot reach another tenant's roster.
+        self._authorize_supervisor_for(service)
+
+        service.connect_agent("support", 3, "sup-uuid", "tenant-b")
+
+        service.confd.users.get.assert_called_once_with(
+            "sup-uuid", tenant_uuid="tenant-b"
+        )
+        service.confd.agents.get.assert_called_once_with(7, tenant_uuid="tenant-b")
+        service.agentd.agents.agent_login_to_queue.assert_called_once_with(
+            3, 42, tenant_uuid="tenant-b"
+        )
+
+    def test_supervisor_without_agent_is_rejected(self, service):
+        service.confd.users.get.return_value = {"agent": None}
+
+        with pytest.raises(SupervisorNotInQueue):
+            service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.agentd.agents.agent_login_to_queue.assert_not_called()
+
+    def test_supervisor_not_in_target_queue_is_rejected(self, service):
+        service.confd.users.get.return_value = {"agent": {"id": 7}}
+        service.confd.agents.get.return_value = {
+            "queues": [{"id": 99, "name": "sales"}]
+        }
+
+        with pytest.raises(SupervisorNotInQueue):
+            service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.agentd.agents.agent_login_to_queue.assert_not_called()
+
+    def test_connect_agent_not_logged_raises_400(self, service):
+        self._authorize_supervisor_for(service)
+        service.agentd.agents.agent_login_to_queue.side_effect = AgentdClientError(
+            NOT_LOGGED
+        )
+
+        with pytest.raises(AgentNotLogged) as exc:
+            service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        assert exc.value.status_code == 400
+
+    def test_no_such_queue_raises_404(self, service):
+        self._authorize_supervisor_for(service)
+        service.agentd.agents.agent_login_to_queue.side_effect = AgentdClientError(
+            NO_SUCH_QUEUE
+        )
+
+        with pytest.raises(NoSuchAgentOrQueue) as exc:
+            service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        assert exc.value.status_code == 404
+
+    def test_no_such_agent_raises_404(self, service):
+        self._authorize_supervisor_for(service)
+        service.agentd.agents.agent_logoff_from_queue.side_effect = AgentdClientError(
+            NO_SUCH_AGENT
+        )
+
+        with pytest.raises(NoSuchAgentOrQueue):
+            service.disconnect_agent("support", 3, "sup-uuid", "t1")
+
+    def test_connect_already_in_queue_is_idempotent(self, service):
+        self._authorize_supervisor_for(service)
+        service.agentd.agents.agent_login_to_queue.side_effect = AgentdClientError(
+            ALREADY_IN_QUEUE
+        )
+
+        # No exception: the target state is already reached.
+        service.connect_agent("support", 3, "sup-uuid", "t1")
+
+    def test_disconnect_not_in_queue_is_idempotent(self, service):
+        self._authorize_supervisor_for(service)
+        service.agentd.agents.agent_logoff_from_queue.side_effect = AgentdClientError(
+            NOT_IN_QUEUE
+        )
+
+        service.disconnect_agent("support", 3, "sup-uuid", "t1")
+
+    def test_unknown_agentd_error_raises_502(self, service):
+        self._authorize_supervisor_for(service)
+        service.agentd.agents.agent_login_to_queue.side_effect = AgentdClientError(
+            "invalid token or unauthorized"
+        )
+
+        with pytest.raises(AgentdUpstreamError) as exc:
+            service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        assert exc.value.status_code == 502

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.4.1
+version: 2.5.0
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/api.yml
+++ b/wazo_calld_queue/api.yml
@@ -103,6 +103,62 @@ paths:
             $ref: '#/definitions/QueuePauseMember'
         '503':
           $ref: '#/responses/AnotherServiceUnavailable'
+  /queues/{queue_name}/connect:
+    put:
+      summary: Connect an agent to a queue (supervisor action)
+      description: >-
+        **Required ACL:** `calld.queues.{queue_name}.connect.update`
+
+
+        Connect the targeted agent to the queue. The caller (token user) must be
+        an agent that is itself a member of the target queue; otherwise the
+        request is rejected. Delegated to `wazo-agentd`; the change is reflected
+        through the existing `queue_agents_status` event (no dedicated event).
+        Already-connected agents return `204` (idempotent).
+      parameters:
+        - $ref: '#/parameters/QueueName'
+        - $ref: '#/parameters/QueueAgentAction'
+      tags:
+      - queues
+      responses:
+        '204':
+          description: Agent has been connected to the queue
+        '400':
+          description: The targeted agent has no active session (must log in first)
+        '403':
+          description: The supervisor is not a member of this queue
+        '404':
+          description: No such agent or queue
+        '503':
+          $ref: '#/responses/AnotherServiceUnavailable'
+  /queues/{queue_name}/disconnect:
+    put:
+      summary: Disconnect an agent from a queue (supervisor action)
+      description: >-
+        **Required ACL:** `calld.queues.{queue_name}.disconnect.update`
+
+
+        Disconnect the targeted agent from the queue. The caller (token user)
+        must be an agent that is itself a member of the target queue; otherwise
+        the request is rejected. Delegated to `wazo-agentd`; the change is
+        reflected through the existing `queue_agents_status` event (no dedicated
+        event). Already-disconnected agents return `204` (idempotent).
+      parameters:
+        - $ref: '#/parameters/QueueName'
+        - $ref: '#/parameters/QueueAgentAction'
+      tags:
+      - queues
+      responses:
+        '204':
+          description: Agent has been disconnected from the queue
+        '400':
+          description: The targeted agent has no active session
+        '403':
+          description: The supervisor is not a member of this queue
+        '404':
+          description: No such agent or queue
+        '503':
+          $ref: '#/responses/AnotherServiceUnavailable'
   /queues/intercept/{queue_name}:
     post:
       summary: Intercept call in queue waiting list
@@ -269,6 +325,13 @@ definitions:
       reason:
         description: Paused reason
         type: string
+  QueueAgentAction:
+    type: object
+    properties:
+      agent_id:
+        description: Identifier of the agent to connect/disconnect
+        type: integer
+        required: true
   InterceptCall:
     type: object
     properties:
@@ -308,6 +371,13 @@ parameters:
     required: true
     schema:
       $ref: '#/definitions/QueuePauseMember'
+  QueueAgentAction:
+    name: body
+    in: body
+    description: The agent to connect/disconnect
+    required: true
+    schema:
+      $ref: '#/definitions/QueueAgentAction'
   Intercept:
     name: body
     in: body

--- a/wazo_calld_queue/exceptions.py
+++ b/wazo_calld_queue/exceptions.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0+
+
+from xivo.rest_api_helpers import APIException
+
+
+class SupervisorNotInQueue(APIException):
+    def __init__(self, queue_name):
+        super().__init__(
+            403,
+            'Supervisor is not a member of this queue',
+            'supervisor-not-in-queue',
+            details={'queue_name': queue_name},
+        )
+
+
+class AgentNotLogged(APIException):
+    def __init__(self):
+        super().__init__(
+            400,
+            'Agent must be logged in before being connected to a queue',
+            'agent-not-logged',
+        )
+
+
+class NoSuchAgentOrQueue(APIException):
+    def __init__(self):
+        super().__init__(404, 'No such agent or queue', 'no-such-agent-or-queue')
+
+
+class AgentdUpstreamError(APIException):
+    def __init__(self, original_error):
+        super().__init__(
+            502,
+            'Unexpected error from wazo-agentd',
+            'agentd-error',
+            details={'original_error': str(original_error)},
+        )

--- a/wazo_calld_queue/plugin.py
+++ b/wazo_calld_queue/plugin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from wazo_amid_client import Client as AmidClient
@@ -15,6 +15,8 @@ from .resources import (
     QueuePauseMemberResource,
     QueueLiveStatsResource,
     QueueAgentsStatusResource,
+    QueueConnectAgentResource,
+    QueueDisconnectAgentResource,
 )
 from .services import QueueService
 from .bus_consume import QueuesBusEventHandler
@@ -79,6 +81,16 @@ class Plugin(object):
         api.add_resource(
             QueueAgentsStatusResource,
             "/queues/agents_status",
+            resource_class_args=[queues_service],
+        )
+        api.add_resource(
+            QueueConnectAgentResource,
+            "/queues/<queue_name>/connect",
+            resource_class_args=[queues_service],
+        )
+        api.add_resource(
+            QueueDisconnectAgentResource,
+            "/queues/<queue_name>/disconnect",
             resource_class_args=[queues_service],
         )
         api.add_resource(

--- a/wazo_calld_queue/resources.py
+++ b/wazo_calld_queue/resources.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 
 from flask import request
 from xivo.tenant_flask_helpers import Tenant
 
-from wazo_calld.auth import required_acl
+from wazo_calld.auth import get_token_user_uuid_from_request, required_acl
 from wazo_calld.http import AuthResource
 
 from .schema import (
     intercept_schema,
+    queue_agent_action_schema,
     queue_list_schema,
     queue_schema,
     queue_member_schema,
@@ -98,6 +99,38 @@ class QueueAgentsStatusResource(AuthResource):
         result = self._queues_service.agents_status(tenant.uuid)
 
         return result, 200
+
+
+class QueueConnectAgentResource(AuthResource):
+    def __init__(self, queues_service):
+        self._queues_service = queues_service
+
+    @required_acl("calld.queues.{queue_name}.connect.update")
+    def put(self, queue_name):
+        body = queue_agent_action_schema.load(request.get_json(force=True))
+        tenant = Tenant.autodetect()
+        supervisor_uuid = get_token_user_uuid_from_request()
+        self._queues_service.connect_agent(
+            queue_name, body["agent_id"], supervisor_uuid, tenant.uuid
+        )
+
+        return "", 204
+
+
+class QueueDisconnectAgentResource(AuthResource):
+    def __init__(self, queues_service):
+        self._queues_service = queues_service
+
+    @required_acl("calld.queues.{queue_name}.disconnect.update")
+    def put(self, queue_name):
+        body = queue_agent_action_schema.load(request.get_json(force=True))
+        tenant = Tenant.autodetect()
+        supervisor_uuid = get_token_user_uuid_from_request()
+        self._queues_service.disconnect_agent(
+            queue_name, body["agent_id"], supervisor_uuid, tenant.uuid
+        )
+
+        return "", 204
 
 
 class InterceptResource(AuthResource):

--- a/wazo_calld_queue/schema.py
+++ b/wazo_calld_queue/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from marshmallow import (
@@ -61,7 +61,15 @@ class InterceptSchema(Schema):
     call_id = fields.Str()
     destination = fields.Str()
 
+
+class QueueAgentActionSchema(Schema):
+    agent_id = fields.Integer(required=True)
+
+    class Meta:
+        strict = True
+
 intercept_schema = InterceptSchema()
 queue_list_schema = QueueListSchema()
 queue_schema = QueueSchema()
 queue_member_schema = QueueMemberSchema()
+queue_agent_action_schema = QueueAgentActionSchema()

--- a/wazo_calld_queue/services.py
+++ b/wazo_calld_queue/services.py
@@ -1,5 +1,25 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
+
+import logging
+
+from wazo_agentd_client.error import (
+    AgentdClientError,
+    ALREADY_IN_QUEUE,
+    NOT_IN_QUEUE,
+    NOT_LOGGED,
+    NO_SUCH_AGENT,
+    NO_SUCH_QUEUE,
+)
+
+from .exceptions import (
+    AgentdUpstreamError,
+    AgentNotLogged,
+    NoSuchAgentOrQueue,
+    SupervisorNotInQueue,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class QueueService(object):
@@ -52,6 +72,66 @@ class QueueService(object):
             "Reason": params.get("reason"),
         }
         return self.amid.action("queuepause", pause_member)
+
+    def connect_agent(self, queue_name, agent_id, supervisor_uuid, tenant_uuid):
+        queue_id = self._authorize_supervisor(
+            supervisor_uuid, queue_name, tenant_uuid
+        )
+        logger.info(
+            "supervisor %s connects agent %s to queue %s (id %s, tenant %s)",
+            supervisor_uuid,
+            agent_id,
+            queue_name,
+            queue_id,
+            tenant_uuid,
+        )
+        self._delegate(
+            self.agentd.agents.agent_login_to_queue, agent_id, queue_id, tenant_uuid
+        )
+
+    def disconnect_agent(self, queue_name, agent_id, supervisor_uuid, tenant_uuid):
+        queue_id = self._authorize_supervisor(
+            supervisor_uuid, queue_name, tenant_uuid
+        )
+        logger.info(
+            "supervisor %s disconnects agent %s from queue %s (id %s, tenant %s)",
+            supervisor_uuid,
+            agent_id,
+            queue_name,
+            queue_id,
+            tenant_uuid,
+        )
+        self._delegate(
+            self.agentd.agents.agent_logoff_from_queue,
+            agent_id,
+            queue_id,
+            tenant_uuid,
+        )
+
+    def _authorize_supervisor(self, supervisor_uuid, queue_name, tenant_uuid):
+        """Return the target queue_id iff the supervisor is a member of it."""
+        user = self.confd.users.get(supervisor_uuid, tenant_uuid=tenant_uuid)
+        agent = user.get("agent")
+        if not agent:
+            raise SupervisorNotInQueue(queue_name)
+        supervisor_agent = self.confd.agents.get(agent["id"], tenant_uuid=tenant_uuid)
+        for queue in supervisor_agent.get("queues") or []:
+            if queue.get("name") == queue_name:
+                return queue["id"]
+        raise SupervisorNotInQueue(queue_name)
+
+    def _delegate(self, action, agent_id, queue_id, tenant_uuid):
+        try:
+            action(agent_id, queue_id, tenant_uuid=tenant_uuid)
+        except AgentdClientError as e:
+            code = getattr(e, "error", None)
+            if code == NOT_LOGGED:
+                raise AgentNotLogged()
+            if code in (NO_SUCH_QUEUE, NO_SUCH_AGENT):
+                raise NoSuchAgentOrQueue()
+            if code in (ALREADY_IN_QUEUE, NOT_IN_QUEUE):
+                return  # PUT is idempotent: the target state is reached
+            raise AgentdUpstreamError(code)
 
     def livestats(self, queue_name):
         return self.publisher.get_stats(queue_name)

--- a/wazo_calld_queue/services.py
+++ b/wazo_calld_queue/services.py
@@ -77,33 +77,33 @@ class QueueService(object):
         queue_id = self._authorize_supervisor(
             supervisor_uuid, queue_name, tenant_uuid
         )
+        self._delegate(
+            self.agentd.agents.agent_login_to_queue, agent_id, queue_id, tenant_uuid
+        )
         logger.info(
-            "supervisor %s connects agent %s to queue %s (id %s, tenant %s)",
+            "supervisor %s connected agent %s to queue %s (id %s, tenant %s)",
             supervisor_uuid,
             agent_id,
             queue_name,
             queue_id,
             tenant_uuid,
-        )
-        self._delegate(
-            self.agentd.agents.agent_login_to_queue, agent_id, queue_id, tenant_uuid
         )
 
     def disconnect_agent(self, queue_name, agent_id, supervisor_uuid, tenant_uuid):
         queue_id = self._authorize_supervisor(
             supervisor_uuid, queue_name, tenant_uuid
         )
-        logger.info(
-            "supervisor %s disconnects agent %s from queue %s (id %s, tenant %s)",
-            supervisor_uuid,
-            agent_id,
-            queue_name,
-            queue_id,
-            tenant_uuid,
-        )
         self._delegate(
             self.agentd.agents.agent_logoff_from_queue,
             agent_id,
+            queue_id,
+            tenant_uuid,
+        )
+        logger.info(
+            "supervisor %s disconnected agent %s from queue %s (id %s, tenant %s)",
+            supervisor_uuid,
+            agent_id,
+            queue_name,
             queue_id,
             tenant_uuid,
         )


### PR DESCRIPTION
## Summary

Implements **issue #3**: per-queue agent **connect / disconnect** reserved to a **supervisor who is a member of that queue**.

Two new REST endpoints in the `wazo-calld` plugin, acting as an **authorization proxy + delegation to `wazo-agentd`**:

| Method | Path | Caller ACL | Effect |
|---|---|---|---|
| `PUT` | `/queues/<queue_name>/connect` | `calld.queues.{queue_name}.connect.update` | connects the target agent to the queue |
| `PUT` | `/queues/<queue_name>/disconnect` | `calld.queues.{queue_name}.disconnect.update` | disconnects the target agent from the queue |

Body: `{ "agent_id": <int> }`. Success: `204`.

The server **authorizes the caller server-side**: the token user must be an agent that is itself a member of the target queue (resolved via confd `user → agent → queue roster`), then delegates to agentd (`agent_login_to_queue` / `agent_logoff_from_queue`). The `queue_id` sent to agentd comes from the **supervisor's own roster**, never from the request body. All confd/agentd calls are tenant-scoped.

No AMI action, no in-memory state mutation, and **no new bus event**: the change propagates through the existing `QueueMemberAdded/Removed` events and the `queue_agents_status` payload.

### Error mapping
| agentd outcome | HTTP |
|---|---|
| success | `204` |
| `ALREADY_IN_QUEUE` / `NOT_IN_QUEUE` | `204` (idempotent — target state reached) |
| `NOT_LOGGED` (no active session) | `400` |
| `NO_SUCH_QUEUE` / `NO_SUCH_AGENT` | `404` |
| supervisor not a member of the queue | `403` |
| any other agentd error | `502` |

## Changes
- **services**: `connect_agent` / `disconnect_agent` + `_authorize_supervisor` + `_delegate` error mapping, with audit logging.
- **resources / plugin**: two `AuthResource` endpoints and route registration.
- **exceptions** (new): `SupervisorNotInQueue` (403), `AgentNotLogged` (400), `NoSuchAgentOrQueue` (404), `AgentdUpstreamError` (502).
- **schema**: `QueueAgentActionSchema`.
- **ACL**: `agentd.agents.*.queues.*.{login,logoff}.update` on the service token (`etc/wazo-auth-keys/conf.d/call_queue.yml`).
- **docs**: `api.yml` (Swagger), `FRONTEND_INTEGRATION.md`, `CHANGELOG.md` (`2.5.0`), `wazo/plugin.yml` (`2.5.0`).

## Test plan
- [x] `pytest tests/` → **94 passing**, built via TDD (RED → GREEN → REFACTOR).
- [x] New `TestConnectDisconnectAgent`: authorized connect/disconnect, supervisor-without-agent, queue-not-in-roster, tenant-isolation, not-logged (400), no-such-queue/agent (404), idempotent already/not-in-queue (204), unknown-error (502).
- [x] conftest stubs for `xivo.rest_api_helpers` and `wazo_agentd_client.error` (neither installed for isolated unit tests).
- [x] agentd client API (method signatures + error-code constants) verified against upstream `wazo-agentd-client` source.
- [x] Dedicated code review + security review (no auth bypass, no IDOR, no cross-tenant leak); copyright headers bumped and audit logging added per review.
- [ ] Integration test against a live `wazo-calld` (`resources.py` is integration-level by nature, per `AGENTS.md`).

Closes #3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authorization and delegation paths affect who can change agent queue membership; tenant-scoped confd checks and supervisor-in-queue rules mitigate IDOR, but behavior depends on agentd/confd correctness.
> 
> **Overview**
> Adds **supervisor-scoped** `PUT /queues/{queue_name}/connect` and `/disconnect` (body `{"agent_id": <int>}`) so a queue member can log another agent in or out of **one** queue through `wazo-agentd`, without AMI or local cache updates.
> 
> **Authorization** resolves the caller via confd (`user → agent → queues`) and requires membership in the target queue; `queue_id` for agentd comes from the supervisor’s roster, with tenant on all confd/agentd calls. **HTTP mapping** includes idempotent `204` for `ALREADY_IN_QUEUE` / `NOT_IN_QUEUE`, plus `400` / `403` / `404` / `502` via new `exceptions` and `_delegate` in `QueueService`.
> 
> Wires new `AuthResource` handlers, `QueueAgentActionSchema`, service-token ACLs for agentd login/logoff, Swagger and frontend docs, version **2.5.0**, and unit tests (including conftest stubs for isolated runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258a14bf60f05b84903ab13e63b665ccf5a491bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->