### PR TITLE
feat: auto-login agent on connect when no agentd session

### DIFF
--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -100,12 +100,18 @@ agent that is itself a member of `{queue_name}`. The action is delegated to
 `queue_agents_status` event (the target agent's `queues` gains/loses the queue),
 so a client only needs to keep merging that event as usual.
 
+If the targeted agent is authenticated to the app but has **no active
+`wazo-agentd` session** (it never took its post), `connect` performs a full
+agent login on its own line (the extension/context are resolved from confd) and
+then leaves it in **only** the selected queue. So a supervisor can connect an
+agent from cold, not just move an already-logged-in agent between queues.
+
 Error codes:
 
 | Code | Meaning |
 |---|---|
 | `204` | Done. Also returned when the agent is **already** (dis)connected (idempotent). |
-| `400` | The targeted agent has no active session — it must log in before being connected. |
+| `400` | The targeted agent has no line to log in on (`connect`), or no active session (`disconnect`). |
 | `403` | The caller is not a member of `{queue_name}` (not allowed to supervise it). |
 | `404` | No such agent or queue. |
 | `502` | Unexpected error from `wazo-agentd`. |

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -16,6 +16,7 @@ from wazo_agentd_client.error import (
 
 from wazo_calld_queue.exceptions import (
     AgentdUpstreamError,
+    AgentHasNoLine,
     AgentNotLogged,
     NoSuchAgentOrQueue,
     SupervisorNotInQueue,
@@ -247,16 +248,99 @@ class TestConnectDisconnectAgent:
 
         service.agentd.agents.agent_login_to_queue.assert_not_called()
 
-    def test_connect_agent_not_logged_raises_400(self, service):
-        self._authorize_supervisor_for(service)
-        service.agentd.agents.agent_login_to_queue.side_effect = AgentdClientError(
-            NOT_LOGGED
+    def _setup_fresh_login(
+        self,
+        service,
+        queue_id=42,
+        queue_name="support",
+        target_agent_id=3,
+        target_queues=None,
+        user_uuid="user-3",
+        lines=None,
+    ):
+        """Supervisor authorized for the queue; target agent (not yet logged
+        into agentd) resolves to a user with a line/extension via confd."""
+        if target_queues is None:
+            target_queues = [{"id": queue_id, "name": queue_name}]
+        if lines is None:
+            lines = [{"extensions": [{"exten": "1001", "context": "default"}]}]
+        users = {
+            "sup-uuid": {"agent": {"id": 7}},
+            user_uuid: {"lines": lines},
+        }
+        agents = {
+            7: {"queues": [{"id": queue_id, "name": queue_name}]},
+            target_agent_id: {
+                "id": target_agent_id,
+                "users": [{"uuid": user_uuid}],
+                "queues": target_queues,
+            },
+        }
+        service.confd.users.get.side_effect = (
+            lambda uuid, tenant_uuid=None: users[uuid]
+        )
+        service.confd.agents.get.side_effect = (
+            lambda agent_id, tenant_uuid=None: agents[agent_id]
+        )
+        # First connect attempt fails (no agentd session), the post-login
+        # "ensure selected queue" call then succeeds.
+        service.agentd.agents.agent_login_to_queue.side_effect = [
+            AgentdClientError(NOT_LOGGED),
+            None,
+        ]
+
+    def test_connect_not_logged_performs_full_login(self, service):
+        # An agent authenticated to WDA but with no agentd session must be
+        # logged in (login_agent) on its own line, not rejected with 400.
+        self._setup_fresh_login(service)
+
+        service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.confd.users.get.assert_any_call("user-3", tenant_uuid="t1")
+        service.agentd.agents.login_agent.assert_called_once_with(
+            3, "1001", "default", tenant_uuid="t1"
         )
 
-        with pytest.raises(AgentNotLogged) as exc:
+    def test_connect_not_logged_keeps_only_selected_queue(self, service):
+        # A full login joins every configured queue; strict single-queue
+        # connect prunes the others and ensures the selected one.
+        self._setup_fresh_login(
+            service,
+            target_queues=[
+                {"id": 42, "name": "support"},
+                {"id": 99, "name": "sales"},
+            ],
+        )
+
+        service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.agentd.agents.agent_logoff_from_queue.assert_called_once_with(
+            3, 99, tenant_uuid="t1"
+        )
+        # The selected queue is (re)ensured after login.
+        assert (
+            service.agentd.agents.agent_login_to_queue.call_args_list[-1].args
+            == (3, 42)
+        )
+
+    def test_connect_already_logged_does_not_relogin(self, service):
+        # Additive per-queue connect for an already-logged-in agent must not
+        # trigger a full login nor prune its other queues.
+        self._authorize_supervisor_for(service)
+
+        service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.agentd.agents.login_agent.assert_not_called()
+        service.agentd.agents.agent_logoff_from_queue.assert_not_called()
+
+    def test_connect_not_logged_without_line_raises_400(self, service):
+        self._setup_fresh_login(service, lines=[])
+
+        with pytest.raises(AgentHasNoLine) as exc:
             service.connect_agent("support", 3, "sup-uuid", "t1")
 
         assert exc.value.status_code == 400
+        service.agentd.agents.login_agent.assert_not_called()
 
     def test_no_such_queue_raises_404(self, service):
         self._authorize_supervisor_for(service)

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.5.0
+version: 2.6.0
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/api.yml
+++ b/wazo_calld_queue/api.yml
@@ -115,6 +115,12 @@ paths:
         request is rejected. Delegated to `wazo-agentd`; the change is reflected
         through the existing `queue_agents_status` event (no dedicated event).
         Already-connected agents return `204` (idempotent).
+
+
+        If the targeted agent has no active `wazo-agentd` session, it is logged
+        in on its own line (resolved from confd) and joined to *only* this
+        queue. A `400` is returned only when the agent has no line to log in
+        on.
       parameters:
         - $ref: '#/parameters/QueueName'
         - $ref: '#/parameters/QueueAgentAction'
@@ -124,7 +130,7 @@ paths:
         '204':
           description: Agent has been connected to the queue
         '400':
-          description: The targeted agent has no active session (must log in first)
+          description: The targeted agent has no line to log in on
         '403':
           description: The supervisor is not a member of this queue
         '404':

--- a/wazo_calld_queue/exceptions.py
+++ b/wazo_calld_queue/exceptions.py
@@ -23,6 +23,16 @@ class AgentNotLogged(APIException):
         )
 
 
+class AgentHasNoLine(APIException):
+    def __init__(self, agent_id):
+        super().__init__(
+            400,
+            'Agent has no line to log in on',
+            'agent-has-no-line',
+            details={'agent_id': agent_id},
+        )
+
+
 class NoSuchAgentOrQueue(APIException):
     def __init__(self):
         super().__init__(404, 'No such agent or queue', 'no-such-agent-or-queue')

--- a/wazo_calld_queue/services.py
+++ b/wazo_calld_queue/services.py
@@ -14,6 +14,7 @@ from wazo_agentd_client.error import (
 
 from .exceptions import (
     AgentdUpstreamError,
+    AgentHasNoLine,
     AgentNotLogged,
     NoSuchAgentOrQueue,
     SupervisorNotInQueue,
@@ -77,9 +78,17 @@ class QueueService(object):
         queue_id = self._authorize_supervisor(
             supervisor_uuid, queue_name, tenant_uuid
         )
-        self._delegate(
-            self.agentd.agents.agent_login_to_queue, agent_id, queue_id, tenant_uuid
-        )
+        try:
+            self._delegate(
+                self.agentd.agents.agent_login_to_queue,
+                agent_id,
+                queue_id,
+                tenant_uuid,
+            )
+        except AgentNotLogged:
+            # The agent is authenticated to WDA but has no agentd session yet:
+            # log it in on its own line, then keep only the selected queue.
+            self._login_agent_to_single_queue(agent_id, queue_id, tenant_uuid)
         logger.info(
             "supervisor %s connected agent %s to queue %s (id %s, tenant %s)",
             supervisor_uuid,
@@ -119,6 +128,44 @@ class QueueService(object):
             if queue.get("name") == queue_name:
                 return queue["id"]
         raise SupervisorNotInQueue(queue_name)
+
+    def _login_agent_to_single_queue(self, agent_id, queue_id, tenant_uuid):
+        """Full agentd login for an agent without a session, then enforce
+        strict single-queue membership on the selected queue.
+
+        ``login_agent`` makes the agent join *every* queue it is configured
+        for in confd, so we prune the others and (re)ensure the selected one
+        (which may not be one of the agent's configured queues).
+        """
+        agent = self.confd.agents.get(agent_id, tenant_uuid=tenant_uuid)
+        extension, context = self._resolve_agent_line(agent_id, agent, tenant_uuid)
+        self.agentd.agents.login_agent(
+            agent_id, extension, context, tenant_uuid=tenant_uuid
+        )
+        for queue in agent.get("queues") or []:
+            if queue["id"] != queue_id:
+                self._delegate(
+                    self.agentd.agents.agent_logoff_from_queue,
+                    agent_id,
+                    queue["id"],
+                    tenant_uuid,
+                )
+        self._delegate(
+            self.agentd.agents.agent_login_to_queue, agent_id, queue_id, tenant_uuid
+        )
+
+    def _resolve_agent_line(self, agent_id, agent, tenant_uuid):
+        """Resolve the agent's (extension, context) from confd via its user's
+        primary line. Raise ``AgentHasNoLine`` if none is configured."""
+        for user in agent.get("users") or []:
+            full_user = self.confd.users.get(user["uuid"], tenant_uuid=tenant_uuid)
+            for line in full_user.get("lines") or []:
+                for extension in line.get("extensions") or []:
+                    exten = extension.get("exten")
+                    context = extension.get("context")
+                    if exten and context:
+                        return exten, context
+        raise AgentHasNoLine(agent_id)
 
     def _delegate(self, action, agent_id, queue_id, tenant_uuid):
         try:


### PR DESCRIPTION
## Contexte

Un superviseur qui connecte un agent **authentifié à WDA mais sans session `wazo-agentd`** (il n'a jamais « pris son poste ») recevait une erreur `400` :

> Agent must be logged in before being connected to a queue

C'est la confusion entre deux notions de « login » distinctes :

| Login | Ce que c'est |
|---|---|
| Authentifié à Wazo/WDA | token wazo-auth (session app) |
| Agent loggué (agentd) | l'agent a pris son poste sur une ligne pour recevoir des appels |

`agent_login_to_queue` exige la **seconde** : il ajoute un agent *déjà loggué* à une file supplémentaire, il ne fait pas le login initial.

## Changement

`connect` attrape désormais `NOT_LOGGED` et **logue l'agent de zéro** (`login_agent`) sur sa propre ligne, au lieu de renvoyer 400.

- **Extension/contexte résolus via confd** (`agent → users → ligne primaire → extension`), transparent pour le frontend.
- **File unique stricte** : un login complet rejoint *toutes* les files configurées de l'agent ; on élague les autres pour ne garder que la file sélectionnée, conservant la sémantique « connect par file » (issue #3).
- **Connect additif préservé** : si l'agent a déjà une session agentd, aucun re-login, les autres files sont intactes.
- Le `400` signifie maintenant « l'agent n'a pas de ligne pour se logger » (nouvelle exception `AgentHasNoLine`).

## Fichiers

- `services.py` — `connect_agent`, `_login_agent_to_single_queue`, `_resolve_agent_line`
- `exceptions.py` — `AgentHasNoLine`
- `api.yml` + `docs/FRONTEND_INTEGRATION.md` — sémantique du 400 mise à jour
- `wazo/plugin.yml` — version 2.5.0 → 2.6.0

## Tests

Cycle TDD complet (Red → Green → Refactor). **97 tests passent.**

Nouveaux tests (`tests/test_services.py`) :
- [x] login complet déclenché sur `NOT_LOGGED` (bonne extension/contexte/tenant)
- [x] file unique stricte (purge des autres files, file cible garantie)
- [x] agent déjà loggué → pas de re-login ni de purge
- [x] pas de ligne → `400 AgentHasNoLine`

## Points de vigilance prod

1. L'agent doit avoir une ligne (extension + contexte) configurée dans confd.
2. Le login se fait sur l'extension de la **ligne primaire** de l'agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Supervisor connect now drives full agentd login and multi-step queue membership changes on live agents; misconfigured lines or confd data could affect call routing, though behavior is covered by tests and only applies on the NOT_LOGGED path.
> 
> **Overview**
> Supervisor **`connect`** no longer returns `400` when the target agent is app-authenticated but has no **`wazo-agentd`** session. On `NOT_LOGGED` from `agent_login_to_queue`, the service performs a full **`login_agent`** using extension/context from confd, then enforces membership in **only** the requested queue (log off other configured queues and re-join the selected one).
> 
> Already-logged-in agents keep the previous additive behavior: a single `agent_login_to_queue` with no full login or queue pruning. **`400`** on connect now means **`AgentHasNoLine`** when confd has no usable line/extension; disconnect still uses the prior “no active session” semantics.
> 
> Docs (`api.yml`, `FRONTEND_INTEGRATION.md`), new exception **`agent-has-no-line`**, plugin version **2.6.0**, and service tests cover cold connect, single-queue pruning, idempotent logged-in connect, and no-line errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f606345cf462fe5e97c15ad8314a4b035c94129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->