### PR TITLE
fix(is_offline) + feat: reject queue connect when agent WDA is offline

### DIFF
--- a/docs/FRONTEND_INTEGRATION.md
+++ b/docs/FRONTEND_INTEGRATION.md
@@ -114,6 +114,7 @@ Error codes:
 | `400` | The targeted agent has no line to log in on (`connect`), or no active session (`disconnect`). |
 | `403` | The caller is not a member of `{queue_name}` (not allowed to supervise it). |
 | `404` | No such agent or queue. |
+| `409` | (`connect`) The agent's application (WDA) is not connected — its device is unavailable. `error_id: agent-wda-not-connected`. Tell the supervisor the agent must reconnect WDA first. Also fires when the agent still has an agentd session but its WDA dropped (the same condition as `is_offline: true`). |
 | `502` | Unexpected error from `wazo-agentd`. |
 
 ---

--- a/docs/ISSUE-agentd-fresh-login-missing-per-queue-event.md
+++ b/docs/ISSUE-agentd-fresh-login-missing-per-queue-event.md
@@ -1,0 +1,203 @@
+# Issue report — `login_agent` does not emit per-queue login events
+
+> Target project: **`wazo-platform/wazo-agentd`**
+> Filed from: `wazo-calld-queue` (supervisor connect/disconnect plugin)
+> Status: ready to file upstream. This file is kept in-repo as the canonical
+> trace; the "Suggested fix" still needs to be validated against agentd's DAO.
+
+## Summary
+
+When an agent is logged in via a **full login** (`POST /agents/.../login`,
+i.e. `LoginAction._do_login`), agentd adds the agent to **every enabled queue**
+at the Asterisk/DB level but publishes **only** a global
+`AgentStatusUpdatedEvent(status='logged_in')`. It does **not** publish a
+per-queue `UserAgentQueueLoggedInEvent` for the queues it just joined.
+
+Any client that builds an agent's queue membership from the **per-queue**
+events (`user_agent_queue_logged_in` / `user_agent_queue_logged_off`,
+routing `agentd.agents.{agent_id}.queues.{queue_id}.login.updated`) — including
+the standard Wazo agent app (WDA) — therefore never learns, in real time, which
+queues the full login joined. The queue list only becomes correct after a
+client reload that re-fetches the status over REST.
+
+## Impact (observed)
+
+Scenario: a **supervisor** connects an agent that has **no agentd session**
+(logged off from all queues) to a queue, through the `wazo-calld-queue` plugin
+(`PUT /queues/{queue_name}/connect`). The plugin performs a full
+`login_agent(...)` because the agent has no session.
+
+On the agent's **standard WDA**, immediately after the connect:
+
+- Global status flips to **"Disponible / Available"** (driven by
+  `AgentStatusUpdatedEvent('logged_in')`). ✅
+- **"MES FILES" stays empty** — `0/0 active`, warning *"Vous n'êtes enregistré
+  dans aucune file d'attente"*, and the **pause button is disabled** (no queue
+  to pause). ❌
+- After a **manual reload** of WDA (which re-fetches the status over REST), the
+  queue appears correctly (`1/1 active`). ✅
+
+So the data is correct everywhere; only the **live, event-driven** queue list in
+clients is stale until a REST refresh.
+
+## Environment
+
+- Wazo platform: current (agentd sources copyright 2025–2026).
+- Reproduced on `ucaas-demo.wazo.io`.
+- Agent configured for a single queue (`support-88511897`); no agentd session
+  before the action.
+
+## Root cause — code trace
+
+### 1. Full login emits only the global status event
+
+`wazo_agentd/service/action/login.py` — `LoginAction._do_login`:
+
+```python
+def _do_login(self, agent, extension, context, interface, state_interface):
+    self._update_agent_status(agent, extension, context, interface, state_interface)
+    self._update_queue_log(agent, extension, context)
+    with db_utils.session_scope():
+        enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
+    self._update_asterisk(agent, interface, state_interface, enabled_queues)  # QueueAdd for ALL enabled queues
+    self._update_blf(agent)
+    self._send_bus_status_update(agent)            # only AgentStatusUpdatedEvent('logged_in')
+    self._ensure_queues_logged_in(agent, enabled_queues)
+```
+
+- `_update_asterisk(...)` issues an AMI `QueueAdd` for **every** enabled queue —
+  the agent really is added to its queues.
+- `_send_bus_status_update(...)` publishes
+  `AgentStatusUpdatedEvent(agent.id, 'logged_in', tenant_uuid, users)`. Its
+  payload is just `{status, agent_id}` — **no queue list**.
+- `_ensure_queues_logged_in(...)` returns immediately when `enabled_queues` is
+  non-empty:
+
+  ```python
+  def _ensure_queues_logged_in(self, agent, enabled_queues):
+      if enabled_queues or not agent.queues:
+          return   # <-- taken: no per-queue login events emitted
+      ...
+  ```
+
+Net result of a full login: **zero `UserAgentQueueLoggedInEvent`** even though
+the agent was just added to one or more queues.
+
+### 2. The per-queue event is only emitted by `login_to_queue`, gated on `not logged`
+
+`wazo_agentd/service/manager/queue.py` — `QueueManager.login_to_queue`:
+
+```python
+def login_to_queue(self, agent, queue):
+    ...
+    agent_queue = self._get_agent_queue(agent_status, queue)
+    ...
+    if not agent_queue.logged:                                   # <-- gate
+        self._add_to_queue_action.add_agent_to_queue_by_status(agent_status, queue)
+        self._send_bus_event(UserAgentQueueLoggedInEvent, agent, agent_queue)
+```
+
+So `UserAgentQueueLoggedInEvent` is published **only** when the queue was not
+already logged. After a full login, the queue is already `logged=True`, so a
+subsequent `login_to_queue` for that same queue is a **silent no-op**.
+
+### 3. The events clients rely on
+
+`wazo_bus/resources/user_agent/event.py`:
+
+```python
+class UserAgentQueueLoggedInEvent(MultiUserEvent):
+    service = 'agentd'
+    name = 'user_agent_queue_logged_in'
+    routing_key_fmt = 'agentd.agents.{agent_id}.queues.{queue_id}.login.updated'
+    required_acl_fmt = 'events.statuses.agents'
+```
+
+These are **user-scoped** (`MultiUserEvent` with `user_uuids`), so when emitted
+they *are* delivered to the agent's own WebSocket. The agent app uses them to
+keep its per-queue view live; the global `AgentStatusUpdatedEvent` cannot serve
+that purpose because it carries no queue information.
+
+### 4. Event sequence actually delivered to the agent's WDA (repro scenario)
+
+Full login (no prior session), agent enabled only for `support-88511897`:
+
+| Order | Event | Carries queues? | Effect on WDA |
+|---|---|---|---|
+| 1 | `AgentStatusUpdatedEvent('logged_in')` | no | status → "Available" |
+| — | *(no `UserAgentQueueLoggedInEvent`)* | — | queue list stays empty |
+
+→ "Available, 0 queues" exactly as observed. The Asterisk `QueueMemberAdded`
+events do fire, but the standard WDA does not derive its own per-queue list
+from them.
+
+## Expected vs actual
+
+- **Expected:** after any login that joins queues (including a full
+  `login_agent`), clients subscribed to `events.statuses.agents` receive a
+  `UserAgentQueueLoggedInEvent` per joined queue, and can render the agent's
+  queue membership live.
+- **Actual:** a full login emits only the global status event; per-queue login
+  events are emitted only by an explicit `login_to_queue` on a not-yet-logged
+  queue. Externally driven full logins (e.g. supervisor connect) leave clients'
+  queue lists stale until a REST reload.
+
+## Suggested fix (agentd)
+
+Make a full login emit one `UserAgentQueueLoggedInEvent` per queue it actually
+joined, mirroring `QueueManager.login_to_queue`. Concretely, in
+`LoginAction._do_login`, after `_update_asterisk(...)` and the status update,
+publish a per-queue login event for each `enabled_queues` entry — reusing
+`QueueManager._send_bus_event` (or the same event construction) so routing and
+scoping stay identical.
+
+Sketch (to validate against the DAO — confirm `enabled_queues` items expose the
+`id`/`penalty` fields the event needs):
+
+```python
+def _do_login(self, agent, extension, context, interface, state_interface):
+    self._update_agent_status(...)
+    self._update_queue_log(...)
+    with db_utils.session_scope():
+        enabled_queues = self._agent_dao.list_agent_enabled_queues(agent.id)
+    self._update_asterisk(agent, interface, state_interface, enabled_queues)
+    self._update_blf(agent)
+    self._send_bus_status_update(agent)
+    # NEW: announce each queue the full login just joined, so per-queue
+    # subscribers (the agent app) refresh their queue list without a reload.
+    for queue in enabled_queues:
+        self._queue_manager._send_bus_event(UserAgentQueueLoggedInEvent, agent, queue)
+    self._ensure_queues_logged_in(agent, enabled_queues)
+```
+
+(Expose a public helper on `QueueManager` rather than reaching into
+`_send_bus_event`.) The same gap likely exists symmetrically on full logoff vs
+`UserAgentQueueLoggedOffEvent` — worth checking `LogoffAction`.
+
+## Why a client-side / plugin-side workaround is fragile
+
+In `wazo-calld-queue`, the fresh-login path
+(`QueueService._login_agent_to_single_queue`) cannot reliably force the missing
+event by toggling the selected queue off→on:
+
+`QueueManager.logoff_from_queue` triggers a **full agent logoff** when the queue
+being left is the **last logged queue**:
+
+```python
+if agent_status and not any(q.logged for q in agent_status.queues):
+    self._logoff_action.logoff_agent(agent_status)
+```
+
+For a **single-queue** agent (the reproduced case), logging the selected queue
+off is the last logged queue → the whole session is destroyed → the follow-up
+`login_to_queue` fails with `NOT_LOGGED`. So a generic toggle workaround breaks
+exactly the case that triggers the bug. The fix belongs in agentd.
+
+## Related code in `wazo-calld-queue`
+
+- `wazo_calld_queue/services.py` — `connect_agent`, `_login_agent_to_single_queue`
+  (the supervisor connect flow that hits the full-login path).
+- The plugin already republishes the Asterisk `QueueMemberAdded` it consumes as
+  `queue_agents_status` for the **supervisor** dashboard
+  (`wazo_calld_queue/bus_consume.py`), but that is a tenant-scoped supervision
+  event, not the agent self-view event the standard WDA consumes.

--- a/etc/wazo-auth-keys/conf.d/call_queue.yml
+++ b/etc/wazo-auth-keys/conf.d/call_queue.yml
@@ -7,6 +7,7 @@ wazo-calld:
     - 'amid.action.queueadd.create'
     - 'amid.action.queueremove.create'
     - 'amid.action.queuepause.create'
+    - 'amid.action.ExtensionState.create'
     - 'agentd.agents.read'
     - 'agentd.agents.by-id.*.read'
     - 'agentd.agents.*.queues.*.login.update'

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -555,6 +555,46 @@ class TestMemberEventHandlers:
         assert agent["is_ringing"] is False
         assert agent["talked_at"] != ""
 
+    def _status_event(self, status, agent_id=5, member="1001", queue="support"):
+        return {
+            "Event": "QueueMemberStatus",
+            "Membership": "dynamic",
+            "Interface": f"Local/id-{agent_id}@agentcallback",
+            "MemberName": f"Agent/{member}",
+            "Queue": queue,
+            "Status": status,
+            "ChanVariable": {"WAZO_TENANT_UUID": TENANT},
+        }
+
+    def test_member_status_unavailable_flags_offline(self, handler):
+        # A logged-in agent whose WDA/device goes Unavailable (Status 5) must be
+        # flagged is_offline so a supervisor sees the websocket is KO.
+        handler._agents[TENANT] = {
+            5: {"id": 5, "number": "1001", "queues": ["support"], "is_offline": False}
+        }
+
+        handler._queue_member_status(self._status_event("5"))
+
+        assert handler._agents[TENANT][5]["is_offline"] is True
+
+    def test_member_status_available_clears_offline(self, handler):
+        # A WDA that reconnects straight into a non-idle state (ringing / in call)
+        # reports Status 6 / 2, not 1: is_offline must still clear, otherwise an
+        # online agent stays wrongly flagged offline until the next hangup.
+        for status in ("1", "2", "6"):
+            handler._agents[TENANT] = {
+                5: {
+                    "id": 5,
+                    "number": "1001",
+                    "queues": ["support"],
+                    "is_offline": True,
+                }
+            }
+
+            handler._queue_member_status(self._status_event(status))
+
+            assert handler._agents[TENANT][5]["is_offline"] is False, status
+
 
 class TestCallerEventHandlers:
     def test_caller_join_publishes_livestats_and_caller_event(self, handler):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -18,9 +18,15 @@ from wazo_calld_queue.exceptions import (
     AgentdUpstreamError,
     AgentHasNoLine,
     AgentNotLogged,
+    AgentWdaNotConnected,
     NoSuchAgentOrQueue,
     SupervisorNotInQueue,
 )
+
+# AMI ExtensionState ``Status`` codes (AST_EXTENSION_*): 0 idle / reachable,
+# 4 unavailable (device unregistered -> WDA application disconnected).
+WDA_CONNECTED = "0"
+WDA_UNAVAILABLE = "4"
 from wazo_calld_queue.services import QueueService
 
 
@@ -186,21 +192,50 @@ class TestConnectDisconnectAgent:
     """Per-queue connect/disconnect: authorize the supervisor against the
     target queue (confd), then delegate to agentd."""
 
-    def _authorize_supervisor_for(self, service, queue_name="support", queue_id=42):
-        service.confd.users.get.return_value = {"agent": {"id": 7}}
-        service.confd.agents.get.return_value = {
-            "queues": [{"id": queue_id, "name": queue_name}]
+    def _authorize_supervisor_for(
+        self,
+        service,
+        queue_name="support",
+        queue_id=42,
+        target_agent_id=3,
+        user_uuid="user-3",
+        lines=None,
+        wda_status=WDA_CONNECTED,
+    ):
+        """Supervisor authorized for the queue; the target agent already has an
+        agentd session (``agent_login_to_queue`` succeeds) and resolves to a
+        user with a line whose device (WDA) reports ``wda_status``."""
+        if lines is None:
+            lines = [{"extensions": [{"exten": "1001", "context": "default"}]}]
+        users = {
+            "sup-uuid": {"agent": {"id": 7}},
+            user_uuid: {"lines": lines},
         }
+        agents = {
+            7: {"queues": [{"id": queue_id, "name": queue_name}]},
+            target_agent_id: {
+                "id": target_agent_id,
+                "users": [{"uuid": user_uuid}],
+                "queues": [{"id": queue_id, "name": queue_name}],
+            },
+        }
+        service.confd.users.get.side_effect = (
+            lambda uuid, tenant_uuid=None: users[uuid]
+        )
+        service.confd.agents.get.side_effect = (
+            lambda agent_id, tenant_uuid=None: agents[agent_id]
+        )
+        service.amid.action.return_value = [
+            {"Response": "Success", "Status": wda_status}
+        ]
 
     def test_connect_authorized_delegates_to_agentd(self, service):
         self._authorize_supervisor_for(service)
 
         service.connect_agent("support", 3, "sup-uuid", "t1")
 
-        service.confd.users.get.assert_called_once_with(
-            "sup-uuid", tenant_uuid="t1"
-        )
-        service.confd.agents.get.assert_called_once_with(7, tenant_uuid="t1")
+        service.confd.users.get.assert_any_call("sup-uuid", tenant_uuid="t1")
+        service.confd.agents.get.assert_any_call(7, tenant_uuid="t1")
         service.agentd.agents.agent_login_to_queue.assert_called_once_with(
             3, 42, tenant_uuid="t1"
         )
@@ -221,10 +256,8 @@ class TestConnectDisconnectAgent:
 
         service.connect_agent("support", 3, "sup-uuid", "tenant-b")
 
-        service.confd.users.get.assert_called_once_with(
-            "sup-uuid", tenant_uuid="tenant-b"
-        )
-        service.confd.agents.get.assert_called_once_with(7, tenant_uuid="tenant-b")
+        service.confd.users.get.assert_any_call("sup-uuid", tenant_uuid="tenant-b")
+        service.confd.agents.get.assert_any_call(7, tenant_uuid="tenant-b")
         service.agentd.agents.agent_login_to_queue.assert_called_once_with(
             3, 42, tenant_uuid="tenant-b"
         )
@@ -288,6 +321,10 @@ class TestConnectDisconnectAgent:
             AgentdClientError(NOT_LOGGED),
             None,
         ]
+        # The agent's WDA device is reachable so the pre-connect check passes.
+        service.amid.action.return_value = [
+            {"Response": "Success", "Status": WDA_CONNECTED}
+        ]
 
     def test_connect_not_logged_performs_full_login(self, service):
         # An agent authenticated to WDA but with no agentd session must be
@@ -332,6 +369,31 @@ class TestConnectDisconnectAgent:
 
         service.agentd.agents.login_agent.assert_not_called()
         service.agentd.agents.agent_logoff_from_queue.assert_not_called()
+
+    def test_connect_rejected_when_wda_not_connected(self, service):
+        # Case 1 at connect time: the agent may still hold an agentd session,
+        # but its WDA/device is Unavailable. Reject with a clear 409 so the
+        # front can warn the supervisor, and never touch agentd.
+        self._authorize_supervisor_for(service, wda_status=WDA_UNAVAILABLE)
+
+        with pytest.raises(AgentWdaNotConnected) as exc:
+            service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        assert exc.value.status_code == 409
+        assert exc.value.id_ == "agent-wda-not-connected"
+        service.agentd.agents.agent_login_to_queue.assert_not_called()
+        service.agentd.agents.login_agent.assert_not_called()
+
+    def test_connect_checks_wda_on_agent_extension(self, service):
+        # The WDA check queries the device state of the agent's own line
+        # (resolved exten/context), not the supervisor's.
+        self._authorize_supervisor_for(service)
+
+        service.connect_agent("support", 3, "sup-uuid", "t1")
+
+        service.amid.action.assert_called_once_with(
+            "ExtensionState", {"Exten": "1001", "Context": "default"}
+        )
 
     def test_connect_not_logged_without_line_raises_400(self, service):
         self._setup_fresh_login(service, lines=[])

--- a/wazo_calld_queue/api.yml
+++ b/wazo_calld_queue/api.yml
@@ -121,6 +121,14 @@ paths:
         in on its own line (resolved from confd) and joined to *only* this
         queue. A `400` is returned only when the agent has no line to log in
         on.
+
+
+        Before connecting, the agent's application (WDA) must be connected: its
+        device must be registered. If the device is unavailable (websocket KO),
+        the request is rejected with `409` (`agent-wda-not-connected`) so the
+        supervisor can be told to have the agent reconnect first — this also
+        catches an agent that still holds a `wazo-agentd` session while its WDA
+        has dropped.
       parameters:
         - $ref: '#/parameters/QueueName'
         - $ref: '#/parameters/QueueAgentAction'
@@ -135,6 +143,10 @@ paths:
           description: The supervisor is not a member of this queue
         '404':
           description: No such agent or queue
+        '409':
+          description: >-
+            The agent's application (WDA) is not connected
+            (`agent-wda-not-connected`)
         '503':
           $ref: '#/responses/AnotherServiceUnavailable'
   /queues/{queue_name}/disconnect:

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -549,28 +549,34 @@ class QueuesBusEventHandler(object):
 
         # QueueMemberStatus
         if event["Event"] == "QueueMemberStatus" and event["Membership"] == "dynamic":
-            if event["Status"] == "5":
-                # WDA is disconnected - websocket KO
-                agents[tenant_uuid][agent]["is_offline"] = True
+            state = agents[tenant_uuid][agent]
+            # ``is_offline`` tracks the device/WDA reachability of a *logged-in*
+            # agent: Asterisk reports Status 5 (Unavailable) when the member's
+            # device is unregistered — i.e. the WDA websocket is KO while the
+            # agent is still logged into the queue. Every other status means the
+            # device is reachable, so derive ``is_offline`` from the status on
+            # each event rather than only clearing it on hangup (Status 1):
+            # a WDA that reconnects straight into a ringing/in-call state
+            # (Status 6/2) would otherwise stay wrongly flagged offline.
+            state["is_offline"] = event["Status"] == "5"
             if event["Status"] == "6":
                 # Ringing
-                agents[tenant_uuid][agent]["is_ringing"] = True
+                state["is_ringing"] = True
             if event["Status"] == "2":
                 # In comm
-                agents[tenant_uuid][agent]["is_talking"] = True
-                agents[tenant_uuid][agent]["is_ringing"] = False
-                agents[tenant_uuid][agent]["talked_at"] = (
-                    datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f")
+                state["is_talking"] = True
+                state["is_ringing"] = False
+                state["talked_at"] = datetime.datetime.now().strftime(
+                    "%Y-%m-%dT%H:%M:%S.%f"
                 )
 
             if event["Status"] == "1":
                 # Hangup
-                agents[tenant_uuid][agent]["is_talking"] = False
-                agents[tenant_uuid][agent]["is_ringing"] = False
-                agents[tenant_uuid][agent]["is_offline"] = False
-                agents[tenant_uuid][agent]["talked_at"] = ""
-                agents[tenant_uuid][agent]["talked_with_number"] = ""
-                agents[tenant_uuid][agent]["talked_with_name"] = ""
+                state["is_talking"] = False
+                state["is_ringing"] = False
+                state["talked_at"] = ""
+                state["talked_with_number"] = ""
+                state["talked_with_name"] = ""
 
         if event["Event"] == "QueueMemberAdded" and event["Membership"] == "dynamic":
             # Handle connection to a queue (an agent may serve several queues)

--- a/wazo_calld_queue/exceptions.py
+++ b/wazo_calld_queue/exceptions.py
@@ -23,6 +23,16 @@ class AgentNotLogged(APIException):
         )
 
 
+class AgentWdaNotConnected(APIException):
+    def __init__(self, agent_id):
+        super().__init__(
+            409,
+            'Agent application (WDA) is not connected; cannot connect agent to queue',
+            'agent-wda-not-connected',
+            details={'agent_id': agent_id},
+        )
+
+
 class AgentHasNoLine(APIException):
     def __init__(self, agent_id):
         super().__init__(

--- a/wazo_calld_queue/services.py
+++ b/wazo_calld_queue/services.py
@@ -16,11 +16,16 @@ from .exceptions import (
     AgentdUpstreamError,
     AgentHasNoLine,
     AgentNotLogged,
+    AgentWdaNotConnected,
     NoSuchAgentOrQueue,
     SupervisorNotInQueue,
 )
 
 logger = logging.getLogger(__name__)
+
+# AMI ExtensionState ``Status`` for a device with no registered contact: the
+# agent application (WDA) is not connected, so the agent cannot take calls.
+EXTENSION_STATE_UNAVAILABLE = "4"
 
 
 class QueueService(object):
@@ -78,6 +83,15 @@ class QueueService(object):
         queue_id = self._authorize_supervisor(
             supervisor_uuid, queue_name, tenant_uuid
         )
+        # The agent's application (WDA) must be connected before we connect it
+        # to a queue: an agent may still hold an agentd session while its device
+        # is Unavailable (websocket KO — see is_offline / "case 1"), and
+        # connecting it would put a phantom member in the queue. Resolve the
+        # agent's line and check its device state up front so the supervisor
+        # gets a clear, specific error instead of a silent dead member.
+        agent = self.confd.agents.get(agent_id, tenant_uuid=tenant_uuid)
+        extension, context = self._resolve_agent_line(agent_id, agent, tenant_uuid)
+        self._assert_wda_connected(agent_id, extension, context)
         try:
             self._delegate(
                 self.agentd.agents.agent_login_to_queue,
@@ -88,7 +102,9 @@ class QueueService(object):
         except AgentNotLogged:
             # The agent is authenticated to WDA but has no agentd session yet:
             # log it in on its own line, then keep only the selected queue.
-            self._login_agent_to_single_queue(agent_id, queue_id, tenant_uuid)
+            self._login_agent_to_single_queue(
+                agent, extension, context, queue_id, tenant_uuid
+            )
         logger.info(
             "supervisor %s connected agent %s to queue %s (id %s, tenant %s)",
             supervisor_uuid,
@@ -129,16 +145,21 @@ class QueueService(object):
                 return queue["id"]
         raise SupervisorNotInQueue(queue_name)
 
-    def _login_agent_to_single_queue(self, agent_id, queue_id, tenant_uuid):
+    def _login_agent_to_single_queue(
+        self, agent, extension, context, queue_id, tenant_uuid
+    ):
         """Full agentd login for an agent without a session, then enforce
         strict single-queue membership on the selected queue.
+
+        The agent object and its resolved ``(extension, context)`` are passed
+        in by ``connect_agent`` (which already fetched/resolved them for the WDA
+        check), so we don't re-query confd here.
 
         ``login_agent`` makes the agent join *every* queue it is configured
         for in confd, so we prune the others and (re)ensure the selected one
         (which may not be one of the agent's configured queues).
         """
-        agent = self.confd.agents.get(agent_id, tenant_uuid=tenant_uuid)
-        extension, context = self._resolve_agent_line(agent_id, agent, tenant_uuid)
+        agent_id = agent["id"]
         self.agentd.agents.login_agent(
             agent_id, extension, context, tenant_uuid=tenant_uuid
         )
@@ -153,6 +174,24 @@ class QueueService(object):
         self._delegate(
             self.agentd.agents.agent_login_to_queue, agent_id, queue_id, tenant_uuid
         )
+
+    def _assert_wda_connected(self, agent_id, extension, context):
+        """Raise ``AgentWdaNotConnected`` if the agent's device (WDA) is not
+        registered.
+
+        Query Asterisk for the hint state of the agent's own extension via AMI
+        ``ExtensionState``: a ``Status`` of Unavailable means no contact is
+        registered for the device, i.e. the WDA application is not connected.
+        Only an explicit Unavailable blocks the connect — an unknown/absent
+        status is treated as "reachable" so a missing hint never wrongly bars a
+        supervisor from connecting an agent.
+        """
+        response = self.amid.action(
+            "ExtensionState", {"Exten": extension, "Context": context}
+        )
+        for message in response or []:
+            if str(message.get("Status")) == EXTENSION_STATE_UNAVAILABLE:
+                raise AgentWdaNotConnected(agent_id)
 
     def _resolve_agent_line(self, agent_id, agent, tenant_uuid):
         """Resolve the agent's (extension, context) from confd via its user's


### PR DESCRIPTION
## Contexte

Bug rapporté : `is_offline` ne reflète pas correctement l'état de connexion WDA d'un agent. Après clarification, le périmètre retenu est le **cas 1** uniquement (agent **loggué** dans une file mais WDA déconnecté → `is_offline: true`), plus une **erreur claire à la connexion** quand le WDA de l'agent ciblé n'est pas connecté.

> ⚠️ Cette PR embarque aussi le commit `feat: auto-login agent on connect when no agentd session` (`6f60634`), qui n'était présent sur aucune branche distante ni PR. Les changements de cette PR en dépendent (refacto de `_login_agent_to_single_queue`). À merger tel quel, ou à rebaser si une PR dédiée est créée pour l'auto-login.

## Changements

### `fix:` — `is_offline` suit l'état device à chaque `QueueMemberStatus`
- Avant : `is_offline` n'était remis à `False` que sur `Status "1"` (raccrochage). Un WDA qui se reconnectait directement en sonnerie/appel (`Status` 6/2) restait bloqué `is_offline: true`.
- Après : `is_offline = (Status == "5")` est dérivé à **chaque** événement → `true` quand le device est Unavailable (WDA KO en étant loggué), `false` dès qu'un état joignable est rapporté.

### `feat:` — refus de connexion si WDA non connecté
- Nouvelle exception `AgentWdaNotConnected` → **HTTP 409**, `error_id: agent-wda-not-connected`, `details: {agent_id}`.
- `connect_agent` résout la ligne de l'agent (exten/context via confd) puis interroge AMI `ExtensionState` ; si le device est Unavailable (`Status "4"`) → 409 **avant** toute action agentd.
- Couvre aussi le cas 1 (session agentd encore active mais WDA tombé).
- `_login_agent_to_single_queue` refactoré pour réutiliser l'agent/ligne déjà résolus (évite un double appel confd).
- Docs : `api.yml` (réponse 409) + `docs/FRONTEND_INTEGRATION.md` (table d'erreurs).

## Tests
- `tests/test_bus_consume.py` : `Status 5 → is_offline true` ; `Status 1/2/6 → is_offline false`.
- `tests/test_services.py` : connexion rejetée (409) quand WDA Unavailable ; vérification que la sonde `ExtensionState` cible bien l'extension de l'agent ; fixtures connect existantes mises à jour (ligne + état device disponible).
- Suite complète : **101 passed**.

## À valider sur instance
1. Format `ExtensionState` AMI : indisponibilité détectée sur `Status == "4"` (AST_EXTENSION_UNAVAILABLE) ; état inconnu/absent ne bloque pas (conservateur). Confirmer que les lignes WDA exposent un hint passant à Unavailable à la déconnexion.
2. La connexion exige désormais de pouvoir résoudre la ligne de l'agent (sinon `400 agent-has-no-line`), y compris pour un agent déjà loggué — comportement voulu pour la sonde WDA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Supervisor connect now depends on confd line resolution and AMI hint semantics for every connect attempt; misread ExtensionState could block or allow connects incorrectly, but unknown states are treated as reachable by design.
> 
> **Overview**
> Fixes supervisor dashboards showing agents as offline after WDA reconnects without a hangup, and blocks supervisor **connect** when the agent app/device is unreachable.
> 
> **`is_offline` on live agent status:** `QueueMemberStatus` now sets `is_offline` from every event (`true` only for Asterisk status `5`, otherwise `false`), instead of clearing offline only on hangup (`1`). Ringing/in-call reconnects (`6`/`2`) no longer leave a reachable agent stuck offline.
> 
> **Supervisor connect pre-check:** Before any `agentd` call, `connect_agent` resolves the target agent’s extension/context and runs AMI `ExtensionState`. Explicit Unavailable (`4`) raises **`409`** with `agent-wda-not-connected` (including agents with an `agentd` session but a dropped WDA). Auth adds `amid.action.ExtensionState.create`; API and frontend integration docs document the new error. Fresh-login path reuses the same resolved agent/line to avoid duplicate confd lookups.
> 
> Also adds an upstream issue write-up: full `login_agent` in agentd does not emit per-queue login events, which can leave standard WDA queue lists empty until reload (not fixed in this plugin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0f865ee59a6dc97f4072b25ee503739d247000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->