### PR TITLE
fix: keep is_offline accurate across logout/login (release 2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2026-06-25
+
+### Fixed
+- **`is_offline` no longer stays stuck `true` across a logout/login cycle.** An
+  agent that went offline (`QueueMemberStatus` Status 5) while logged into a
+  queue, was then disconnected and later reconnected its WDA and logged back
+  in, kept `is_offline: true` in `GET /queues/agents_status` and the
+  `queue_agents_status` event — because nothing cleared the flag after the
+  re-login. Now:
+  - `is_offline` is reset to `false` when an agent leaves **all** its queues
+    (full logout / confd dissociation to empty), so a stale value never bleeds
+    into the next login;
+  - `QueueMemberAdded` derives `is_offline` from the device `Status` the event
+    already carries (Status 5 → offline), so any (re)join reflects the real
+    device state immediately — including an agent added while its device is
+    still unavailable, which a logout-only reset would miss.
+
 ## [2.6.0] - 2026-06-25
 
 ### Added
@@ -215,6 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release: Queue REST API and bus events for Asterisk-based queue management.
 
+[2.6.1]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/wazo-communication/wazo-calld-queue/compare/v2.4.0...v2.4.1

--- a/tests/test_bus_consume.py
+++ b/tests/test_bus_consume.py
@@ -679,6 +679,43 @@ class TestMultiQueueMembership:
         assert "support" in configured  # pre-existing runtime queue preserved
         assert "sales" in configured
 
+    def test_member_added_clears_offline_when_device_reachable(self, handler):
+        # A (re)join carries the member's current device Status. When the WDA
+        # reconnected before logging back in, no further QueueMemberStatus
+        # follows the join, so derive is_offline from the Added event itself —
+        # otherwise a reconnected agent stays wrongly flagged offline
+        # (Barbara's bug).
+        agent = self._logged_agent(handler, [])
+        agent["is_offline"] = True
+        event = _member_added_event("support")
+        event["Status"] = "1"  # NOT_INUSE -> device reachable
+
+        handler._queue_member_added(event)
+
+        assert handler._agents[TENANT][5]["is_offline"] is False
+
+    def test_member_added_flags_offline_when_device_unavailable(self, handler):
+        # Mirror case a logout-only reset would miss: an agent added while its
+        # device is still Unavailable (Status 5) must surface as offline
+        # immediately.
+        self._logged_agent(handler, [])
+        event = _member_added_event("support")
+        event["Status"] = "5"
+
+        handler._queue_member_added(event)
+
+        assert handler._agents[TENANT][5]["is_offline"] is True
+
+    def test_member_added_without_status_keeps_offline(self, handler):
+        # Not every source carries Status; its absence must not clobber a
+        # known device state.
+        agent = self._logged_agent(handler, [])
+        agent["is_offline"] = True
+
+        handler._queue_member_added(_member_added_event("support"))  # no Status
+
+        assert handler._agents[TENANT][5]["is_offline"] is True
+
     def test_member_removed_from_one_queue_stays_logged(self, handler):
         self._logged_agent(handler, ["support", "sales"])
 
@@ -706,6 +743,19 @@ class TestMultiQueueMembership:
         assert agent["logged_at"] == ""
         assert agent["talked_at"] == ""
         assert agent["talked_with_number"] == ""
+
+    def test_member_removed_from_last_queue_clears_offline(self, handler):
+        # is_offline tracks the device of a *logged-in* agent. Once the agent
+        # leaves all its queues we no longer receive status updates for it, so a
+        # stale True must not survive the logout and bleed into the next login:
+        # an agent that went offline, was disconnected, then reconnects its WDA
+        # and logs back in would otherwise stay wrongly flagged offline.
+        agent = self._logged_agent(handler, ["support"])
+        agent["is_offline"] = True
+
+        handler._queue_member_removed(_member_removed_event("support"))
+
+        assert handler._agents[TENANT][5]["is_offline"] is False
 
     def test_queue_field_is_first_of_queues(self, handler):
         self._logged_agent(handler, ["support"])

--- a/wazo/plugin.yml
+++ b/wazo/plugin.yml
@@ -1,6 +1,6 @@
 name: wazo-calld-queue
 namespace: wazo
-version: 2.6.0
+version: 2.6.1
 author: Sylvain Boily & Mathias WOLFF
 display_name: Queue API and events
 min_wazo_version: 26.06

--- a/wazo_calld_queue/bus_consume.py
+++ b/wazo_calld_queue/bus_consume.py
@@ -77,9 +77,15 @@ def _reset_session_fields(state):
     Shared by ``QueueMemberRemoved`` (last runtime queue left) and
     ``_sync_configured_queues`` (a confd dissociation pruned the last runtime
     queue), so a published ``is_logged: false`` status never carries stale
-    login/call data. ``is_offline`` is intentionally left untouched (it tracks
-    the websocket/device, not the queue session).
+    login/call data. ``is_offline`` is reset too: it tracks the device/WDA of a
+    *logged-in* agent via ``QueueMemberStatus`` events, and once the agent has
+    left all its queues no such event follows — so a stale ``True`` would
+    otherwise survive the logout and bleed into the next login (an agent that
+    went offline, was disconnected, then reconnected its WDA and logged back in
+    would stay wrongly flagged offline). ``False`` matches the neutral default
+    of a freshly-seeded agent (see ``_build_agent_state``).
     """
+    state["is_offline"] = False
     state["is_talking"] = False
     state["is_ringing"] = False
     state["logged_at"] = ""
@@ -608,6 +614,15 @@ class QueuesBusEventHandler:
             if event["Queue"] not in state["configured_queues"]:
                 state["configured_queues"].append(event["Queue"])
             state["interface"] = event["StateInterface"]
+            # A (re)join carries the member's current device Status, so reflect
+            # it on the agent as QueueMemberStatus does (Status 5 = Unavailable
+            # = WDA device unregistered). This refreshes is_offline at the join
+            # itself — crucial when an agent reconnects its WDA and logs back in
+            # without any later status event to clear a stale offline flag. Only
+            # act when the event actually carries Status, so a source that omits
+            # it never clobbers a known device state.
+            if "Status" in event:
+                state["is_offline"] = event["Status"] == "5"
             if not state.get("logged_at"):
                 # LoginTime: set on first observed queue join, kept across
                 # further joins. Keying on the empty timestamp (rather than on


### PR DESCRIPTION
## Bug

An agent (\"Barbara\") logged into a queue goes **offline** (WDA disconnects →
`QueueMemberStatus` Status 5 → `is_offline: true`). A supervisor disconnects
her. She then **reconnects her WDA and logs back into the queue** — yet the
`queue_agents_status` event still shows **`is_offline: true`** while
`is_logged: true`.

### Root cause

`is_offline` was only ever written by the `QueueMemberStatus` handler. On the
re-login path only a **`QueueMemberAdded`** fires (no `QueueMemberStatus`
follows, because the device had already registered *before* the queue login),
and neither the logout (`_reset_session_fields`) nor the `QueueMemberAdded`
handler touched `is_offline` — so the stale `true` survived.

## Fix (A + B)

- **(A)** `_reset_session_fields`: reset `is_offline = false` when an agent
  leaves **all** its queues (full logout / confd dissociation to empty), so a
  stale value never bleeds into the next login. Matches the neutral default of
  a freshly-seeded agent.
- **(B)** `QueueMemberAdded`: derive `is_offline` from the device `Status` the
  event already carries (`Status 5` → offline), so any (re)join reflects the
  real device state immediately — including an agent added while its device is
  **still** unavailable, which a logout-only reset would miss. Guarded on
  `Status` presence so a source omitting it never clobbers a known state.

## Tests (TDD)

Added to `tests/test_bus_consume.py` (RED → GREEN):
- `test_member_removed_from_last_queue_clears_offline` (A)
- `test_member_added_clears_offline_when_device_reachable` (B, Status 1)
- `test_member_added_flags_offline_when_device_unavailable` (B, Status 5)
- `test_member_added_without_status_keeps_offline` (guard: absence ≠ clobber)

**105 tests pass**; full `pre-commit` (black/isort/flake8/mypy/…) green.

## Release

Bumps `wazo/plugin.yml` to **2.6.1** and adds the `[2.6.1]` CHANGELOG entry.

> Based on `docs/changelog-2.6.0` (PR #20) to keep the CHANGELOG diff clean;
> merge after #20 (GitHub will retarget this PR to `master`). A `v2.6.1`
> GitHub release will follow the merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bus-handler change to agent presence reporting with new unit tests; no auth, API contract, or persistence changes.
> 
> **Overview**
> Fixes **`is_offline` staying `true`** after an agent goes offline, is disconnected, reconnects WDA, and logs back in—when only **`QueueMemberAdded`** fires and no follow-up **`QueueMemberStatus`** clears the flag.
> 
> **`_reset_session_fields`** now sets **`is_offline` to `false`** when the agent leaves all queues (same path as full logout / confd prune to empty membership), so a stale offline flag does not carry into the next session.
> 
> **`QueueMemberAdded`** now sets **`is_offline` from the event’s `Status`** when present (`Status` **5** → offline), matching **`QueueMemberStatus`** at join time; if **`Status`** is omitted, the existing value is left unchanged.
> 
> Release **2.6.1** (`wazo/plugin.yml`, **CHANGELOG**); four bus-consume tests cover logout reset, reachable/unavailable join, and the no-**`Status`** guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79002b507df4959e268d82100f093ccdcd1dd79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->